### PR TITLE
Added a Region around the MonoBehaviour methods in the Service Template

### DIFF
--- a/Editor/Templates~/Service.txt
+++ b/Editor/Templates~/Service.txt
@@ -12,7 +12,7 @@ namespace #NAMESPACE#
         }
 		
 	    // Below are the Unity events that are replicated by the Service Framework, simply delete any that are not required.
-        #region MonoBehaviours
+        #region MonoBehaviour callbacks
         /// <inheritdoc />
         public override void Initialize()
         {
@@ -79,6 +79,6 @@ namespace #NAMESPACE#
         {
             // The Unity "OnApplicationPause" MonoBehaviour, called when Unity generates the OnPause event on App pauses or is about to suspend.
         }        
-        #endregion MonoBehaviours
+        #endregion MonoBehaviour callbacks
     }
 }

--- a/Editor/Templates~/Service.txt
+++ b/Editor/Templates~/Service.txt
@@ -12,7 +12,7 @@ namespace #NAMESPACE#
         }
 		
 	    // Below are the Unity events that are replicated by the Service Framework, simply delete any that are not required.
-        
+        #region MonoBehaviours
         /// <inheritdoc />
         public override void Initialize()
         {
@@ -79,5 +79,6 @@ namespace #NAMESPACE#
         {
             // The Unity "OnApplicationPause" MonoBehaviour, called when Unity generates the OnPause event on App pauses or is about to suspend.
         }        
+        #endregion MonoBehaviours
     }
 }

--- a/Editor/Templates~/Service.txt
+++ b/Editor/Templates~/Service.txt
@@ -9,6 +9,8 @@ namespace #NAMESPACE#
         public #NAME#(string name, uint priority, #NAME#Profile profile)
             : base(name, priority)
         {
+            // THe constructor should be used to gather required properties from the profile (or cache the profile) and to ready any components needed.
+            // Note, during this call, not all services will be registered with the Service Framework, so this should only be used to ready this individual servce.
         }
 		
 	    // Below are the Unity events that are replicated by the Service Framework, simply delete any that are not required.
@@ -16,7 +18,8 @@ namespace #NAMESPACE#
         /// <inheritdoc />
         public override void Initialize()
         {
-            // Initialize is called when the Service Framework first instantiates the service.  (Awake)
+            // Initialize is called when the Service Framework first instantiates the service.  ( during MonoBehaviour 'Awake')
+            // This is called AFTER all services have been registered but before the 'Start' call.
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
Added a region around the MonoBehaviour replicator methods in the Service Template

Seems better to be a good citizen and make sure devs can just collapse the region around the Replicated MonoBehaviour methods