### PR TITLE
Fix/handle editor play mode state change

### DIFF
--- a/Editor/ServiceProfileInspector.cs
+++ b/Editor/ServiceProfileInspector.cs
@@ -375,7 +375,7 @@ namespace RealityCollective.ServiceFramework.Editor.Profiles
                 serializedObject.ApplyModifiedProperties();
 
                 //TODO
-                if (ServiceManager.Instance.IsInitialized &&
+                if (ServiceManager.Instance != null && ServiceManager.Instance.IsInitialized &&
                     runtimePlatforms.arraySize > 0 &&
                     systemTypeReference.Type != null)
                 {

--- a/Editor/ServiceProfileInspector.cs
+++ b/Editor/ServiceProfileInspector.cs
@@ -374,7 +374,6 @@ namespace RealityCollective.ServiceFramework.Editor.Profiles
             {
                 serializedObject.ApplyModifiedProperties();
 
-                //TODO
                 if (ServiceManager.Instance != null && ServiceManager.Instance.IsInitialized &&
                     runtimePlatforms.arraySize > 0 &&
                     systemTypeReference.Type != null)

--- a/Editor/Utilities/UnityEditorPlayModeStateChangeHandler.cs
+++ b/Editor/Utilities/UnityEditorPlayModeStateChangeHandler.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEditor;
+using UnityEditor.SceneManagement;
+
+namespace RealityCollective.ServiceFramework.Editor.Utilities
+{
+    /// <summary>
+    /// Editor helper class to detect when the Unity Editor enters play mode, to assist skipping Editor "Validate" functions on Editor start
+    /// </summary>
+    [InitializeOnLoad]
+    public static class UnityEditorPlayModeStateChangeHandler
+    {
+        static UnityEditorPlayModeStateChangeHandler()
+        {
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange playModeState)
+        {
+            var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (EditorApplication.isPlaying ||
+                EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                EditorPrefs.SetBool(ServiceFrameworkStatus.UnityEditorRunStateKey, true);
+            }
+            else
+            {
+                EditorPrefs.SetBool(ServiceFrameworkStatus.UnityEditorRunStateKey, false);
+            }
+        }
+    }
+}

--- a/Editor/Utilities/UnityEditorPlayModeStateChangeHandler.cs
+++ b/Editor/Utilities/UnityEditorPlayModeStateChangeHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEditor;
-using UnityEditor.SceneManagement;
 
 namespace RealityCollective.ServiceFramework.Editor.Utilities
 {
@@ -19,7 +18,6 @@ namespace RealityCollective.ServiceFramework.Editor.Utilities
 
         private static void OnPlayModeStateChanged(PlayModeStateChange playModeState)
         {
-            var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
             if (EditorApplication.isPlaying ||
                 EditorApplication.isPlayingOrWillChangePlaymode)
             {

--- a/Editor/Utilities/UnityEditorPlayModeStateChangeHandler.cs.meta
+++ b/Editor/Utilities/UnityEditorPlayModeStateChangeHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c7ded28890e6c04e99d22cf7f8971b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Utilities/ServiceFrameworkStatus.cs
+++ b/Runtime/Utilities/ServiceFrameworkStatus.cs
@@ -8,7 +8,7 @@ namespace RealityCollective.ServiceFramework
         /// <summary>
         /// Editor Prefs key name to store the current Unity editor play state
         /// </summary>
-        internal const string UnityEditorRunStateKey = "UnityEditorRunState";
+        internal const string UnityEditorRunStateKey = "RealityCollective_UnityEditorRunState";
 
         /// <summary>
         /// Internal editor flag to capture when the Unity Editor is entering Run mode

--- a/Runtime/Utilities/ServiceFrameworkStatus.cs
+++ b/Runtime/Utilities/ServiceFrameworkStatus.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace RealityCollective.ServiceFramework
+{
+    internal static class ServiceFrameworkStatus
+    {
+        /// <summary>
+        /// Editor Prefs key name to store the current Unity editor play state
+        /// </summary>
+        internal const string UnityEditorRunStateKey = "UnityEditorRunState";
+
+        /// <summary>
+        /// Internal editor flag to capture when the Unity Editor is entering Run mode
+        /// </summary>
+        internal static bool EditorPlayModeStateChanging = false;
+    }
+}

--- a/Runtime/Utilities/ServiceFrameworkStatus.cs.meta
+++ b/Runtime/Utilities/ServiceFrameworkStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1dbd00cfb11dab4a87c0850a4e0ae59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Utilities/ServiceManagerInstance.cs
+++ b/Runtime/Utilities/ServiceManagerInstance.cs
@@ -65,7 +65,7 @@ namespace RealityCollective.ServiceFramework
 #if UNITY_EDITOR
         private void OnValidate()
         {
-            var UnityEditorRunState = EditorPrefs.GetBool(ServiceFrameworkStatus.UnityEditorRunStateKey);
+            var unityEditorRunState = EditorPrefs.GetBool(ServiceFrameworkStatus.UnityEditorRunStateKey);
             if(UnityEditorRunState || !gameObject.activeInHierarchy || !enabled)
             {
                 return;

--- a/Runtime/Utilities/ServiceManagerInstance.cs
+++ b/Runtime/Utilities/ServiceManagerInstance.cs
@@ -3,8 +3,11 @@
 
 using RealityCollective.ServiceFramework.Definitions;
 using RealityCollective.ServiceFramework.Services;
-using UnityEditor;
 using UnityEngine;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace RealityCollective.ServiceFramework
 {
@@ -62,7 +65,8 @@ namespace RealityCollective.ServiceFramework
 #if UNITY_EDITOR
         private void OnValidate()
         {
-            if(EditorApplication.isPlaying || !gameObject.activeInHierarchy || !enabled)
+            var UnityEditorRunState = EditorPrefs.GetBool(ServiceFrameworkStatus.UnityEditorRunStateKey);
+            if(UnityEditorRunState || !gameObject.activeInHierarchy || !enabled)
             {
                 return;
             }

--- a/Runtime/Utilities/ServiceManagerInstance.cs
+++ b/Runtime/Utilities/ServiceManagerInstance.cs
@@ -66,7 +66,7 @@ namespace RealityCollective.ServiceFramework
         private void OnValidate()
         {
             var unityEditorRunState = EditorPrefs.GetBool(ServiceFrameworkStatus.UnityEditorRunStateKey);
-            if(UnityEditorRunState || !gameObject.activeInHierarchy || !enabled)
+            if(unityEditorRunState || !gameObject.activeInHierarchy || !enabled)
             {
                 return;
             }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "dependencies": {
     "com.unity.editorcoroutines": "1.0.0",
     "com.unity.addressables": "1.18.15",
-    "com.realitycollective.utilities": "1.0.0-preview.2"
+    "com.realitycollective.utilities": "1.0.0-preview.3"
   }
 }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

Fixes a VERY annoying issue whereby on entering Play Mode, Unity will run "Validate" and attempt to initialise the Service Manager. Where this is normally required for normal Unity Editing, this instance is then destroyed before "Awake" is called.
This fix "finally" allows the Service Manager to "skip" initialisation if the Unity Editor enters play mode and prevents double initialization.

Does not affect normal "Play" mode as this is an editor only behaviour.

Also fixed a minor grievance where the Service Manager for whatever reason is not initialised in the Editor and causes the inspector to throw a null reference exception (rare issue)

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Implemented a "EditorPlayModeStateChange" editor flag, which is set on entering play mode in the editor and reset when it leaves.
- Fixed an edge case where Unity does NOT initialise the Service Framework in the editor that caused a null reference exception in the inspector.

## Breaking Changes
<!--  Are there any breaking changes included in this change that would prevent or cause issue for existing projects? -->

None

