### PR TITLE
Fix wrong interface type returned for service regiatration

### DIFF
--- a/Runtime/Extensions/TypeExtensions.cs
+++ b/Runtime/Extensions/TypeExtensions.cs
@@ -34,11 +34,18 @@ namespace RealityCollective.ServiceFramework.Extensions
                         return returnType;
                     }
 
-                    var types = serviceType.GetInterfaces();
-
-                    for (int i = 0; i < types.Length; i++)
+                    var allInterfaces = new HashSet<Type>(serviceType.GetInterfaces());
+                    if (serviceType.BaseType != null)
                     {
-                        if (IsValidServiceType(types[i], out returnType))
+                        // Remove all the interfaces implemented by the base class, so that now only
+                        // interfaces implemented by the most derived class and interfaces implemented by those
+                        // (interfaces of the most derived class) remain.
+                        allInterfaces.ExceptWith(serviceType.BaseType.GetInterfaces());
+                    }
+
+                    foreach (var typeInterface in allInterfaces)
+                    {
+                        if (IsValidServiceType(typeInterface, out returnType))
                         {
                             break;
                         }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

TypeExtensions.FindServiceInterfaceType returns the wrong interface type for a data provider when there is a more concrete type. This is actually the issue I was reporting the other day. So following scenario, here is the interface hierarchy for the toolkit's teleport providers:

IDashTeleportProvider -> ITeleportLocomotionProvider -> ILocomotionProvider
IBlinkTeleportProvider -> ITeleportLocomotionProvider -> ILocomotionProvider
IInstantTeleportProvider -> ITeleportLocomotionProvider -> ILocomotionProvider

Upon service registration TypeExtensions.FindServiceInterfaceType currently returns ITeleportLocomotionProvider  for all three of them, which obbviously leads to issues as the service container will only register the first one and then fail to register the others since a type of that interface is already registered.
This is because Tyle.GetInterfaces() returns interfaces in an arbitrary order
And then whatever is the first one in the returned array that works for the service is seledcted
Which might not be the best suited candidate

### Manual testing status

Manually tested.
