### PR TITLE
Fix wrong interface type returned due to interface inheritance

### DIFF
--- a/Runtime/Extensions/TypeExtensions.cs
+++ b/Runtime/Extensions/TypeExtensions.cs
@@ -43,6 +43,27 @@ namespace RealityCollective.ServiceFramework.Extensions
                         allInterfaces.ExceptWith(serviceType.BaseType.GetInterfaces());
                     }
 
+                    // We want to remove interfaces that are implemented by other interfaces
+                    // i.e
+                    // public interface A : B {}
+                    // public interface B {}
+                    // public class Top : A {} → We only want to dump interface A so interface B must be removed
+
+                    // Considering class A given above allInterfaces contains A and B now.
+                    var toRemove = new HashSet<Type>();
+                    foreach (var implementedByMostDerivedClass in allInterfaces)
+                    {
+                        // For interface A this will only contain single element, namely B
+                        // For interface B this will an empty array
+                        foreach (var implementedByOtherInterfaces in implementedByMostDerivedClass.GetInterfaces())
+                        {
+                            toRemove.Add(implementedByOtherInterfaces);
+                        }
+                    }
+
+                    // Finally remove the interfaces that do not belong to the most derived class.
+                    allInterfaces.ExceptWith(toRemove);
+
                     foreach (var typeInterface in allInterfaces)
                     {
                         if (IsValidServiceType(typeInterface, out returnType))

--- a/Tests/TestData/Interfaces/ITestDataProvider1.cs
+++ b/Tests/TestData/Interfaces/ITestDataProvider1.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityCollective.ServiceFramework.Interfaces;
 

--- a/Tests/TestData/Interfaces/ITestDataProvider2.cs
+++ b/Tests/TestData/Interfaces/ITestDataProvider2.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Reality Collective. All rights reserved.
-
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityCollective.ServiceFramework.Interfaces;
 

--- a/Tests/TestData/Interfaces/ITestService1.cs
+++ b/Tests/TestData/Interfaces/ITestService1.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityCollective.ServiceFramework.Interfaces;
 

--- a/Tests/TestData/Interfaces/ITestService1DataProvider.cs
+++ b/Tests/TestData/Interfaces/ITestService1DataProvider.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) Reality Collective. All rights reserved.
+// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityCollective.ServiceFramework.Interfaces;
 
 namespace RealityCollective.ServiceFramework.Tests.Interfaces
 {
-    public interface ITestService2 : IService { }
+    public interface ITestService1DataProvider : IServiceDataProvider { }
 }

--- a/Tests/TestData/Interfaces/ITestService1DataProvider.cs.meta
+++ b/Tests/TestData/Interfaces/ITestService1DataProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 538b763ca008fe841a4f8acc66639892
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestData/Interfaces/ITestService1DataProviderA.cs
+++ b/Tests/TestData/Interfaces/ITestService1DataProviderA.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace RealityCollective.ServiceFramework.Tests.Interfaces
+{
+    public interface ITestService1DataProviderA : ITestService1DataProvider { }
+}

--- a/Tests/TestData/Interfaces/ITestService1DataProviderA.cs.meta
+++ b/Tests/TestData/Interfaces/ITestService1DataProviderA.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 787db93d66e0f4c4e9c1c902db9942f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestData/Interfaces/ITestService1DataProviderB.cs
+++ b/Tests/TestData/Interfaces/ITestService1DataProviderB.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace RealityCollective.ServiceFramework.Tests.Interfaces
+{
+    public interface ITestService1DataProviderB : ITestService1DataProvider { }
+}

--- a/Tests/TestData/Interfaces/ITestService1DataProviderB.cs.meta
+++ b/Tests/TestData/Interfaces/ITestService1DataProviderB.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 21c9795d988e8994a93951b8ab54ebff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestData/Profiles/TestService1Profile.cs
+++ b/Tests/TestData/Profiles/TestService1Profile.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using RealityCollective.ServiceFramework.Definitions;
 using RealityCollective.ServiceFramework.Interfaces;
 

--- a/Tests/TestData/Profiles/TestService2Profile.cs
+++ b/Tests/TestData/Profiles/TestService2Profile.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using RealityCollective.ServiceFramework.Definitions;
 using RealityCollective.ServiceFramework.Interfaces;
 

--- a/Tests/TestData/Providers/BaseTestService1DataProvider.cs
+++ b/Tests/TestData/Providers/BaseTestService1DataProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Reality Collective. All rights reserved.
+// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityCollective.ServiceFramework.Definitions;
@@ -9,11 +9,12 @@ using UnityEngine;
 
 namespace RealityCollective.ServiceFramework.Tests.Providers
 {
-    public class TestDataProvider2 : BaseServiceDataProvider, ITestDataProvider2
+    [System.Runtime.InteropServices.Guid("f5309e95-8811-4200-8831-49a8043d6afa")]
+    public class BaseTestService1DataProvider : BaseServiceDataProvider, ITestService1DataProvider
     {
-        public const string TestName = "Test Data Provider 2";
+        public const string TestName = "BaseTestService1DataProvider";
 
-        public TestDataProvider2(string name = TestName, uint priority = 2, BaseProfile profile = null, IService parentService = null)
+        public BaseTestService1DataProvider(string name = TestName, uint priority = 1, BaseProfile profile = null, IService parentService = null)
             : base(name, priority, profile, parentService)
         { }
 

--- a/Tests/TestData/Providers/BaseTestService1DataProvider.cs.meta
+++ b/Tests/TestData/Providers/BaseTestService1DataProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5946fcdb30a848448ede0049227bb52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestData/Providers/TestDataProvider1.cs
+++ b/Tests/TestData/Providers/TestDataProvider1.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityCollective.ServiceFramework.Definitions;
 using RealityCollective.ServiceFramework.Interfaces;

--- a/Tests/TestData/Providers/TestService1DataProviderA.cs
+++ b/Tests/TestData/Providers/TestService1DataProviderA.cs
@@ -1,19 +1,19 @@
-﻿// Copyright (c) Reality Collective. All rights reserved.
+// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityCollective.ServiceFramework.Definitions;
 using RealityCollective.ServiceFramework.Interfaces;
-using RealityCollective.ServiceFramework.Providers;
 using RealityCollective.ServiceFramework.Tests.Interfaces;
 using UnityEngine;
 
 namespace RealityCollective.ServiceFramework.Tests.Providers
 {
-    public class TestDataProvider2 : BaseServiceDataProvider, ITestDataProvider2
+    [System.Runtime.InteropServices.Guid("725535fd-25a8-4d79-b3bd-6f6865df2adb")]
+    public class TestService1DataProviderA : BaseTestService1DataProvider, ITestService1DataProviderA
     {
-        public const string TestName = "Test Data Provider 2";
+        public new const string TestName = "TestService1DataProviderA";
 
-        public TestDataProvider2(string name = TestName, uint priority = 2, BaseProfile profile = null, IService parentService = null)
+        public TestService1DataProviderA(string name = TestName, uint priority = 1, BaseProfile profile = null, IService parentService = null)
             : base(name, priority, profile, parentService)
         { }
 

--- a/Tests/TestData/Providers/TestService1DataProviderA.cs.meta
+++ b/Tests/TestData/Providers/TestService1DataProviderA.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e60c7b0bb5502aa4992f2f6b8aa3390f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestData/Providers/TestService1DataProviderB.cs
+++ b/Tests/TestData/Providers/TestService1DataProviderB.cs
@@ -1,19 +1,19 @@
-﻿// Copyright (c) Reality Collective. All rights reserved.
+// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityCollective.ServiceFramework.Definitions;
 using RealityCollective.ServiceFramework.Interfaces;
-using RealityCollective.ServiceFramework.Providers;
 using RealityCollective.ServiceFramework.Tests.Interfaces;
 using UnityEngine;
 
 namespace RealityCollective.ServiceFramework.Tests.Providers
 {
-    public class TestDataProvider2 : BaseServiceDataProvider, ITestDataProvider2
+    [System.Runtime.InteropServices.Guid("df746fcc-cf9b-414f-bf7e-0d311cfdd8ac")]
+    public class TestService1DataProviderB : BaseTestService1DataProvider, ITestService1DataProviderB
     {
-        public const string TestName = "Test Data Provider 2";
+        public new const string TestName = "TestService1DataProviderB";
 
-        public TestDataProvider2(string name = TestName, uint priority = 2, BaseProfile profile = null, IService parentService = null)
+        public TestService1DataProviderB(string name = TestName, uint priority = 1, BaseProfile profile = null, IService parentService = null)
             : base(name, priority, profile, parentService)
         { }
 

--- a/Tests/TestData/Providers/TestService1DataProviderB.cs.meta
+++ b/Tests/TestData/Providers/TestService1DataProviderB.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6171e357cd8f2c48aeb876f8a526116
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestData/Services/TestService1.cs
+++ b/Tests/TestData/Services/TestService1.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) xRealityLabs. All rights reserved.
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityCollective.ServiceFramework.Definitions;
 using RealityCollective.ServiceFramework.Services;

--- a/Tests/TestData/Services/TestService2.cs
+++ b/Tests/TestData/Services/TestService2.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) xRealityLabs. All rights reserved.
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using RealityCollective.ServiceFramework.Definitions;
 using RealityCollective.ServiceFramework.Services;

--- a/Tests/Tests/Service Interface Type Tests.cs
+++ b/Tests/Tests/Service Interface Type Tests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using NUnit.Framework;
+using RealityCollective.ServiceFramework.Tests.Services;
+using RealityCollective.ServiceFramework.Extensions;
+using RealityCollective.ServiceFramework.Tests.Interfaces;
+using RealityCollective.ServiceFramework.Tests.Providers;
+
+namespace RealityCollective.ServiceFramework.Tests
+{
+    internal class ServiceInterfaceTypeTests
+    {
+        [Test]
+        public void Test_TestService1_Type()
+        {
+            var testService1 = new TestService1();
+            var interfaceType = testService1.GetType().FindServiceInterfaceType(typeof(ITestService1));
+
+            Assert.AreEqual(typeof(ITestService1), interfaceType);
+        }
+
+        [Test]
+        public void Test_TestService2_Type()
+        {
+            var testService2 = new TestService2();
+            var interfaceType = testService2.GetType().FindServiceInterfaceType(typeof(ITestService2));
+
+            Assert.AreEqual(typeof(ITestService2), interfaceType);
+        }
+
+        [Test]
+        public void Test_TestDataProvider1_Type()
+        {
+            var testService1 = new TestService1(nameof(TestService1), 0, null);
+            var testDataProvider1 = new TestDataProvider1(nameof(TestDataProvider1), 1, null, testService1);
+            var interfaceType = testDataProvider1.GetType().FindServiceInterfaceType(typeof(ITestDataProvider1));
+
+            Assert.AreEqual(typeof(ITestDataProvider1), interfaceType);
+        }
+
+        [Test]
+        public void Test_TestDataProvider2_Type()
+        {
+            var testService2 = new TestService2(nameof(TestService2), 0, null);
+            var testDataProvider2 = new TestDataProvider2(nameof(TestDataProvider2), 1, null, testService2);
+            var interfaceType = testDataProvider2.GetType().FindServiceInterfaceType(typeof(ITestDataProvider2));
+
+            Assert.AreEqual(typeof(ITestDataProvider2), interfaceType);
+        }
+
+        [Test]
+        public void Test_BaseTestService1DataProvider_Type()
+        {
+            var testService1 = new TestService1(nameof(TestService1), 0, null);
+            var baseTestService1DataProvider = new BaseTestService1DataProvider(nameof(BaseTestService1DataProvider), 1, null, testService1);
+            var interfaceType = baseTestService1DataProvider.GetType().FindServiceInterfaceType(typeof(ITestService1DataProvider));
+
+            Assert.AreEqual(typeof(ITestService1DataProvider), interfaceType);
+        }
+
+        [Test]
+        public void Test_TestService1DataProviderA_Type()
+        {
+            var testService1 = new TestService1(nameof(TestService1), 0, null);
+            var testService1DataProviderA = new TestService1DataProviderA(nameof(TestService1DataProviderA), 1, null, testService1);
+            var interfaceType = testService1DataProviderA.GetType().FindServiceInterfaceType(typeof(ITestService1DataProviderA));
+
+            Assert.AreEqual(typeof(ITestService1DataProviderA), interfaceType);
+        }
+
+        [Test]
+        public void Test_TestService1DataProviderB_Type()
+        {
+            var testService1 = new TestService1(nameof(TestService1), 0, null);
+            var testService1DataProviderB = new TestService1DataProviderB(nameof(TestService1DataProviderB), 1, null, testService1);
+            var interfaceType = testService1DataProviderB.GetType().FindServiceInterfaceType(typeof(ITestService1DataProviderB));
+
+            Assert.AreEqual(typeof(ITestService1DataProviderB), interfaceType);
+        }
+    }
+}

--- a/Tests/Tests/Service Interface Type Tests.cs.meta
+++ b/Tests/Tests/Service Interface Type Tests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 324a4dea12a156d4e9a83d8cc719ea19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

There was still edge cases where `FindServiceInterfaceType` would return the wrong interface type, namely the base interface type of a service and cause registration issues. This PR addresses that and further improves filtering of interfaces.

### Testing Status

Added Unit Tests

### Manual testing status

Tested and verified in custom projects with increased complexity.