### PR TITLE
Fix edge case where service interface type could not be determined and improve tests

### DIFF
--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -979,20 +979,16 @@ namespace RealityCollective.ServiceFramework.Services
 
             if (!CanGetService(interfaceType, serviceName)) { return false; }
 
-            foreach (var activeService in activeServices)
+            if (activeServices.TryGetValue(interfaceType, out var service))
             {
-                var activeServiceType = activeService.Key;
-                if (interfaceType.IsAssignableFrom(activeServiceType))
+                serviceInstance = service;
+
+                if (CheckServiceMatch(interfaceType, serviceName, interfaceType, service))
                 {
-                    serviceInstance = activeService.Value;
-
-                    if (CheckServiceMatch(interfaceType, serviceName, interfaceType, serviceInstance))
-                    {
-                        return true;
-                    }
-
-                    serviceInstance = null;
+                    return true;
                 }
+
+                serviceInstance = null;
             }
 
             return false;

--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -979,16 +979,20 @@ namespace RealityCollective.ServiceFramework.Services
 
             if (!CanGetService(interfaceType, serviceName)) { return false; }
 
-            if (activeServices.TryGetValue(interfaceType, out var service))
+            foreach (var activeService in activeServices)
             {
-                serviceInstance = service;
-
-                if (CheckServiceMatch(interfaceType, serviceName, interfaceType, service))
+                var activeServiceType = activeService.Key;
+                if (interfaceType.IsAssignableFrom(activeServiceType))
                 {
-                    return true;
-                }
+                    serviceInstance = activeService.Value;
 
-                serviceInstance = null;
+                    if (CheckServiceMatch(interfaceType, serviceName, interfaceType, serviceInstance))
+                    {
+                        return true;
+                    }
+
+                    serviceInstance = null;
+                }
             }
 
             return false;
@@ -1678,7 +1682,7 @@ namespace RealityCollective.ServiceFramework.Services
         /// <returns>True, if the registered service contains the interface type and name.</returns>
         private bool CheckServiceMatch(Type interfaceType, string serviceName, Type registeredInterfaceType, IService serviceInstance)
         {
-            bool isNameValid = string.IsNullOrEmpty(serviceName) || serviceInstance.Name == serviceName;
+            bool isNameValid = string.IsNullOrEmpty(serviceName) || string.Equals(serviceInstance.Name, serviceName);
             bool isInstanceValid = interfaceType == registeredInterfaceType || interfaceType.IsInstanceOfType(serviceInstance);
             return isNameValid && isInstanceValid;
         }

--- a/Tests/TestData/Interfaces/ITestService.cs
+++ b/Tests/TestData/Interfaces/ITestService.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityCollective.ServiceFramework.Interfaces;
+
+namespace RealityCollective.ServiceFramework.Tests.Interfaces
+{
+    /// <summary>
+    /// Common base interface for all services that are used for testing only.
+    /// </summary>
+    public interface ITestService : IService { }
+}

--- a/Tests/TestData/Interfaces/ITestService.cs.meta
+++ b/Tests/TestData/Interfaces/ITestService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15c56fbc48dfca74fb85ca7a7ab9ef48
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestData/Interfaces/ITestService1.cs
+++ b/Tests/TestData/Interfaces/ITestService1.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using RealityCollective.ServiceFramework.Interfaces;
-
 namespace RealityCollective.ServiceFramework.Tests.Interfaces
 {
-    public interface ITestService1 : IService { }
+    public interface ITestService1 : ITestService { }
 }

--- a/Tests/TestData/Interfaces/ITestService2.cs
+++ b/Tests/TestData/Interfaces/ITestService2.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using RealityCollective.ServiceFramework.Interfaces;
-
 namespace RealityCollective.ServiceFramework.Tests.Interfaces
 {
-    public interface ITestService2 : IService { }
+    public interface ITestService2 : ITestService { }
 }

--- a/Tests/Tests/ServiceManager_GetService_Tests.cs
+++ b/Tests/Tests/ServiceManager_GetService_Tests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using NUnit.Framework;
+using RealityCollective.ServiceFramework.Services;
+using RealityCollective.ServiceFramework.Tests.Interfaces;
+using RealityCollective.ServiceFramework.Tests.Services;
+using RealityCollective.ServiceFramework.Tests.Utilities;
+
+namespace RealityCollective.ServiceFramework.Tests
+{
+    /// <summary>
+    /// This class contains tests for all <see cref="ServiceManager"/> APIs
+    /// used to retrieve a registered service instance.
+    /// </summary>
+    internal class ServiceManager_GetService_Tests
+    {
+        private ServiceManager serviceManager;
+
+        [SetUp]
+        public void SetupServiceManager_GetService_Tests()
+        {
+            TestUtilities.InitializeServiceManagerScene(ref serviceManager);
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using said interface type.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_TopInterfaceType()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService1>(serviceInstance);
+
+            // Act
+            var retrievedService = serviceManager.GetService<ITestService1>();
+
+            // Assert
+            Assert.IsNotNull(retrievedService);
+            Assert.IsTrue(retrievedService is ITestService1);
+            Assert.IsTrue(retrievedService == serviceInstance);
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
+        /// was registered using it's dedicated interface type <see cref="ITestService1"/>.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_BaseInterfaceType()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService1>(serviceInstance);
+
+            // Act
+            var retrievedService = serviceManager.GetService<ITestService>();
+
+            // Assert
+            Assert.IsNotNull(retrievedService);
+            Assert.IsTrue(retrievedService is ITestService);
+            Assert.IsTrue(retrievedService == serviceInstance);
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using the base interface type <see cref="ITestService"/>.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService>(serviceInstance);
+
+            // Act
+            var retrievedService = serviceManager.GetService<ITestService1>();
+
+            // Assert
+            Assert.IsNotNull(retrievedService);
+            Assert.IsTrue(retrievedService is ITestService1);
+            Assert.IsTrue(retrievedService == serviceInstance);
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
+        /// was registered using the base interface type <see cref="ITestService"/>.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_BaseInterfaceType_RegisteredByBaseInterfaceType()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService>(serviceInstance);
+
+            // Act
+            var retrievedService = serviceManager.GetService<ITestService>();
+
+            // Assert
+            Assert.IsNotNull(retrievedService);
+            Assert.IsTrue(retrievedService is ITestService);
+            Assert.IsTrue(retrievedService == serviceInstance);
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve the service instances <see cref="TestService1"/>
+        /// and <see cref="TestService2"/> using their respective dedicated interface types <see cref="ITestService1"/>
+        /// and <see cref="ITestService2"/>. Additionally the test ensures both service instances can be retrieved
+        /// using the base interface type <see cref="ITestService"/>.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetServices_BaseInterfaceType()
+        {
+            // Arrange
+            var serviceInstance1 = new TestService1();
+            serviceManager.TryRegisterService<ITestService1>(serviceInstance1);
+            var serviceInstance2 = new TestService2();
+            serviceManager.TryRegisterService<ITestService2>(serviceInstance2);
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService>();
+            var retrievedService1 = serviceManager.GetService<ITestService1>();
+            var retrievedServices1 = serviceManager.GetServices<ITestService1>();
+            var retrievedService2 = serviceManager.GetService<ITestService2>();
+            var retrievedServices2 = serviceManager.GetServices<ITestService2>();
+
+            // Assert
+            Assert.IsTrue(retrievedServices.Count == 2);
+            Assert.IsTrue(retrievedServices.Contains(serviceInstance1));
+            Assert.IsTrue(retrievedServices.Contains(serviceInstance2));
+            Assert.IsNotNull(retrievedService1);
+            Assert.IsTrue(retrievedService1 is ITestService1);
+            Assert.IsTrue(retrievedService1 == serviceInstance1);
+            Assert.IsTrue(retrievedServices1.Count == 1);
+            Assert.IsNotNull(retrievedService2);
+            Assert.IsTrue(retrievedService2 is ITestService2);
+            Assert.IsTrue(retrievedService2 == serviceInstance2);
+            Assert.IsTrue(retrievedServices2.Count == 1);
+        }
+
+        [TearDown]
+        public void TearDownServiceManager_GetService_Tests()
+        {
+            serviceManager.Dispose();
+            serviceManager = null;
+        }
+    }
+}

--- a/Tests/Tests/ServiceManager_GetService_Tests.cs
+++ b/Tests/Tests/ServiceManager_GetService_Tests.cs
@@ -7,7 +7,7 @@ using RealityCollective.ServiceFramework.Tests.Interfaces;
 using RealityCollective.ServiceFramework.Tests.Services;
 using RealityCollective.ServiceFramework.Tests.Utilities;
 
-namespace RealityCollective.ServiceFramework.Tests
+namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 {
     /// <summary>
     /// This class contains tests for all <see cref="ServiceManager"/> APIs
@@ -46,6 +46,29 @@ namespace RealityCollective.ServiceFramework.Tests
 
         /// <summary>
         /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using said interface type.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_TopInterfaceType_WithPopulation()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService1>(serviceInstance);
+            var serviceInstance2 = new TestService2();
+            serviceManager.TryRegisterService<ITestService2>(serviceInstance2);
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService1>();
+
+            // Assert
+            Assert.IsNotNull(retrievedServices);
+            Assert.IsTrue(retrievedServices.Count == 1);
+            Assert.IsTrue(retrievedServices[0] is ITestService1);
+            Assert.IsTrue(retrievedServices[0] == serviceInstance);
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
         /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
         /// was registered using it's dedicated interface type <see cref="ITestService1"/>.
         /// </summary>
@@ -64,6 +87,31 @@ namespace RealityCollective.ServiceFramework.Tests
             Assert.IsTrue(retrievedServices.Count == 1);
             Assert.IsTrue(retrievedServices[0] is ITestService);
             Assert.IsTrue(retrievedServices[0] == serviceInstance);
+        }
+
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
+        /// was registered using it's dedicated interface type <see cref="ITestService1"/>.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_BaseInterfaceType_WithPopulation()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService1>(serviceInstance);
+            var serviceInstance2 = new TestService2();
+            serviceManager.TryRegisterService<ITestService2>(serviceInstance2);
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService>();
+
+            // Assert
+            Assert.IsNotNull(retrievedServices, "No services returned from registry");
+            Assert.IsTrue(retrievedServices.Count == 2, $"Number of services did not match the expected [2]");
+            Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service is not of type {typeof(ITestService)}");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
         }
 
         /// <summary>
@@ -89,6 +137,29 @@ namespace RealityCollective.ServiceFramework.Tests
 
         /// <summary>
         /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using the base interface type <see cref="ITestService"/>.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_WithPopulation()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService>(serviceInstance);
+            var serviceInstance2 = new TestService2();
+            serviceManager.TryRegisterService<ITestService2>(serviceInstance2);
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService1>();
+
+            // Assert
+            Assert.IsNotNull(retrievedServices, "No services returned from registry");
+            Assert.IsTrue(retrievedServices.Count == 1, $"Number of services did not match the expected [1]");
+            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service is not of type {typeof(ITestService)}");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
         /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
         /// was registered using the base interface type <see cref="ITestService"/>.
         /// </summary>
@@ -107,6 +178,30 @@ namespace RealityCollective.ServiceFramework.Tests
             Assert.IsTrue(retrievedServices.Count == 1);
             Assert.IsTrue(retrievedServices[0] is ITestService);
             Assert.IsTrue(retrievedServices[0] == serviceInstance);
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
+        /// was registered using the base interface type <see cref="ITestService"/>.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_BaseInterfaceType_RegisteredByBaseInterfaceType_WithPopulation()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService>(serviceInstance);
+            var serviceInstance2 = new TestService2();
+            serviceManager.TryRegisterService<ITestService2>(serviceInstance2);
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService>();
+
+            // Assert
+            Assert.IsNotNull(retrievedServices, "No services returned from registry");
+            Assert.IsTrue(retrievedServices.Count == 2, $"Number of services did not match the expected [2]");
+            Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service is not of type {typeof(ITestService)}");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
         }
 
         /// <summary>

--- a/Tests/Tests/ServiceManager_GetService_Tests.cs
+++ b/Tests/Tests/ServiceManager_GetService_Tests.cs
@@ -262,6 +262,7 @@ namespace RealityCollective.ServiceFramework.Tests
         public void TearDownServiceManager_GetService_Tests()
         {
             serviceManager.Dispose();
+            serviceManager.DestroyAllServices();
             serviceManager = null;
         }
     }

--- a/Tests/Tests/ServiceManager_GetService_Tests.cs
+++ b/Tests/Tests/ServiceManager_GetService_Tests.cs
@@ -35,12 +35,13 @@ namespace RealityCollective.ServiceFramework.Tests
             serviceManager.TryRegisterService<ITestService1>(serviceInstance);
 
             // Act
-            var retrievedService = serviceManager.GetService<ITestService1>();
+            var retrievedServices = serviceManager.GetServices<ITestService1>();
 
             // Assert
-            Assert.IsNotNull(retrievedService);
-            Assert.IsTrue(retrievedService is ITestService1);
-            Assert.IsTrue(retrievedService == serviceInstance);
+            Assert.IsNotNull(retrievedServices);
+            Assert.IsTrue(retrievedServices.Count == 1);
+            Assert.IsTrue(retrievedServices[0] is ITestService1);
+            Assert.IsTrue(retrievedServices[0] == serviceInstance);
         }
 
         /// <summary>
@@ -56,12 +57,13 @@ namespace RealityCollective.ServiceFramework.Tests
             serviceManager.TryRegisterService<ITestService1>(serviceInstance);
 
             // Act
-            var retrievedService = serviceManager.GetService<ITestService>();
+            var retrievedServices = serviceManager.GetServices<ITestService>();
 
             // Assert
-            Assert.IsNotNull(retrievedService);
-            Assert.IsTrue(retrievedService is ITestService);
-            Assert.IsTrue(retrievedService == serviceInstance);
+            Assert.IsNotNull(retrievedServices);
+            Assert.IsTrue(retrievedServices.Count == 1);
+            Assert.IsTrue(retrievedServices[0] is ITestService);
+            Assert.IsTrue(retrievedServices[0] == serviceInstance);
         }
 
         /// <summary>
@@ -76,12 +78,13 @@ namespace RealityCollective.ServiceFramework.Tests
             serviceManager.TryRegisterService<ITestService>(serviceInstance);
 
             // Act
-            var retrievedService = serviceManager.GetService<ITestService1>();
+            var retrievedServices = serviceManager.GetServices<ITestService1>();
 
             // Assert
-            Assert.IsNotNull(retrievedService);
-            Assert.IsTrue(retrievedService is ITestService1);
-            Assert.IsTrue(retrievedService == serviceInstance);
+            Assert.IsNotNull(retrievedServices);
+            Assert.IsTrue(retrievedServices.Count == 1);
+            Assert.IsTrue(retrievedServices[0] is ITestService1);
+            Assert.IsTrue(retrievedServices[0] == serviceInstance);
         }
 
         /// <summary>
@@ -97,12 +100,13 @@ namespace RealityCollective.ServiceFramework.Tests
             serviceManager.TryRegisterService<ITestService>(serviceInstance);
 
             // Act
-            var retrievedService = serviceManager.GetService<ITestService>();
+            var retrievedServices = serviceManager.GetServices<ITestService>();
 
             // Assert
-            Assert.IsNotNull(retrievedService);
-            Assert.IsTrue(retrievedService is ITestService);
-            Assert.IsTrue(retrievedService == serviceInstance);
+            Assert.IsNotNull(retrievedServices);
+            Assert.IsTrue(retrievedServices.Count == 1);
+            Assert.IsTrue(retrievedServices[0] is ITestService);
+            Assert.IsTrue(retrievedServices[0] == serviceInstance);
         }
 
         /// <summary>
@@ -122,23 +126,21 @@ namespace RealityCollective.ServiceFramework.Tests
 
             // Act
             var retrievedServices = serviceManager.GetServices<ITestService>();
-            var retrievedService1 = serviceManager.GetService<ITestService1>();
             var retrievedServices1 = serviceManager.GetServices<ITestService1>();
-            var retrievedService2 = serviceManager.GetService<ITestService2>();
             var retrievedServices2 = serviceManager.GetServices<ITestService2>();
 
             // Assert
             Assert.IsTrue(retrievedServices.Count == 2);
             Assert.IsTrue(retrievedServices.Contains(serviceInstance1));
             Assert.IsTrue(retrievedServices.Contains(serviceInstance2));
-            Assert.IsNotNull(retrievedService1);
-            Assert.IsTrue(retrievedService1 is ITestService1);
-            Assert.IsTrue(retrievedService1 == serviceInstance1);
+            Assert.IsNotNull(retrievedServices1);
             Assert.IsTrue(retrievedServices1.Count == 1);
-            Assert.IsNotNull(retrievedService2);
-            Assert.IsTrue(retrievedService2 is ITestService2);
-            Assert.IsTrue(retrievedService2 == serviceInstance2);
+            Assert.IsTrue(retrievedServices1[0] is ITestService1);
+            Assert.IsTrue(retrievedServices1[0] == serviceInstance1);
+            Assert.IsNotNull(retrievedServices2);
             Assert.IsTrue(retrievedServices2.Count == 1);
+            Assert.IsTrue(retrievedServices2[0] is ITestService2);
+            Assert.IsTrue(retrievedServices2[0] == serviceInstance2);
         }
 
         [TearDown]

--- a/Tests/Tests/ServiceManager_GetService_Tests.cs
+++ b/Tests/Tests/ServiceManager_GetService_Tests.cs
@@ -39,7 +39,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Assert
             Assert.IsNotNull(retrievedServices);
-            Assert.IsTrue(retrievedServices.Count == 1);
+            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
             Assert.IsTrue(retrievedServices[0] is ITestService1);
             Assert.IsTrue(retrievedServices[0] == serviceInstance);
         }
@@ -47,6 +47,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
         /// <summary>
         /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
         /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using said interface type.
+        /// With multiple services registered
         /// </summary>
         [Test]
         public void ServiceManager_GetService_TopInterfaceType_WithPopulation()
@@ -62,7 +63,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Assert
             Assert.IsNotNull(retrievedServices);
-            Assert.IsTrue(retrievedServices.Count == 1);
+            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
             Assert.IsTrue(retrievedServices[0] is ITestService1);
             Assert.IsTrue(retrievedServices[0] == serviceInstance);
         }
@@ -84,7 +85,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Assert
             Assert.IsNotNull(retrievedServices);
-            Assert.IsTrue(retrievedServices.Count == 1);
+            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
             Assert.IsTrue(retrievedServices[0] is ITestService);
             Assert.IsTrue(retrievedServices[0] == serviceInstance);
         }
@@ -94,6 +95,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
         /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
         /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
         /// was registered using it's dedicated interface type <see cref="ITestService1"/>.
+        /// With multiple services registered
         /// </summary>
         [Test]
         public void ServiceManager_GetService_BaseInterfaceType_WithPopulation()
@@ -109,7 +111,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Assert
             Assert.IsNotNull(retrievedServices, "No services returned from registry");
-            Assert.IsTrue(retrievedServices.Count == 2, $"Number of services did not match the expected [2]");
+            Assert.AreEqual(2, retrievedServices.Count, $"Number of services did not match the expected [2]");
             Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service is not of type {typeof(ITestService)}");
             Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
         }
@@ -130,7 +132,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Assert
             Assert.IsNotNull(retrievedServices);
-            Assert.IsTrue(retrievedServices.Count == 1);
+            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
             Assert.IsTrue(retrievedServices[0] is ITestService1);
             Assert.IsTrue(retrievedServices[0] == serviceInstance);
         }
@@ -138,6 +140,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
         /// <summary>
         /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
         /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using the base interface type <see cref="ITestService"/>.
+        /// With multiple services registered
         /// </summary>
         [Test]
         public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_WithPopulation()
@@ -153,7 +156,56 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Assert
             Assert.IsNotNull(retrievedServices, "No services returned from registry");
-            Assert.IsTrue(retrievedServices.Count == 1, $"Number of services did not match the expected [1]");
+            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
+            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service is not of type {typeof(ITestService)}");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/> 
+        /// with multiple instances of <see cref="TestService1"/> registered using all of its interfaces
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_Twice()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService>(serviceInstance);
+            var serviceInstance2 = new TestService1();
+            serviceManager.TryRegisterService<ITestService1>(serviceInstance2);
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService1>();
+
+            // Assert
+            Assert.IsNotNull(retrievedServices, "No services returned from registry");
+            Assert.AreEqual(2, retrievedServices.Count, $"Number of services did not match the expected [1]");
+            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service is not of type {typeof(ITestService)}");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/> 
+        /// with multiple instances of <see cref="TestService1"/> registered using all of its interfaces
+        /// With multiple services registered
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_Twice_WithPopulation()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService>(serviceInstance);
+            var serviceInstance2 = new TestService1();
+            serviceManager.TryRegisterService<ITestService1>(serviceInstance2);
+            var serviceInstance3 = new TestService2();
+            serviceManager.TryRegisterService<ITestService2>(serviceInstance3);
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService1>();
+
+            // Assert
+            Assert.IsNotNull(retrievedServices, "No services returned from registry");
+            Assert.AreEqual(2, retrievedServices.Count, $"Number of services did not match the expected [1]");
             Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service is not of type {typeof(ITestService)}");
             Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
         }
@@ -175,7 +227,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Assert
             Assert.IsNotNull(retrievedServices);
-            Assert.IsTrue(retrievedServices.Count == 1);
+            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
             Assert.IsTrue(retrievedServices[0] is ITestService);
             Assert.IsTrue(retrievedServices[0] == serviceInstance);
         }
@@ -184,6 +236,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
         /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
         /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
         /// was registered using the base interface type <see cref="ITestService"/>.
+        /// With multiple services registered
         /// </summary>
         [Test]
         public void ServiceManager_GetService_BaseInterfaceType_RegisteredByBaseInterfaceType_WithPopulation()
@@ -199,7 +252,7 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Assert
             Assert.IsNotNull(retrievedServices, "No services returned from registry");
-            Assert.IsTrue(retrievedServices.Count == 2, $"Number of services did not match the expected [2]");
+            Assert.AreEqual(2, retrievedServices.Count, $"Number of services did not match the expected [2]");
             Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service is not of type {typeof(ITestService)}");
             Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
         }
@@ -225,15 +278,15 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
             var retrievedServices2 = serviceManager.GetServices<ITestService2>();
 
             // Assert
-            Assert.IsTrue(retrievedServices.Count == 2);
+            Assert.AreEqual(2, retrievedServices.Count, $"Number of services did not match the expected [2]");
             Assert.IsTrue(retrievedServices.Contains(serviceInstance1));
             Assert.IsTrue(retrievedServices.Contains(serviceInstance2));
             Assert.IsNotNull(retrievedServices1);
-            Assert.IsTrue(retrievedServices1.Count == 1);
+            Assert.AreEqual(1, retrievedServices1.Count, $"Number of services did not match the expected [1]");
             Assert.IsTrue(retrievedServices1[0] is ITestService1);
             Assert.IsTrue(retrievedServices1[0] == serviceInstance1);
             Assert.IsNotNull(retrievedServices2);
-            Assert.IsTrue(retrievedServices2.Count == 1);
+            Assert.AreEqual(1, retrievedServices2.Count, $"Number of services did not match the expected [1]");
             Assert.IsTrue(retrievedServices2[0] is ITestService2);
             Assert.IsTrue(retrievedServices2[0] == serviceInstance2);
         }

--- a/Tests/Tests/ServiceManager_GetService_Tests.cs
+++ b/Tests/Tests/ServiceManager_GetService_Tests.cs
@@ -7,7 +7,7 @@ using RealityCollective.ServiceFramework.Tests.Interfaces;
 using RealityCollective.ServiceFramework.Tests.Services;
 using RealityCollective.ServiceFramework.Tests.Utilities;
 
-namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
+namespace RealityCollective.ServiceFramework.Tests
 {
     /// <summary>
     /// This class contains tests for all <see cref="ServiceManager"/> APIs
@@ -36,36 +36,15 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Act
             var retrievedServices = serviceManager.GetServices<ITestService1>();
+            var retrievedService = serviceManager.GetService<ITestService1>();
 
             // Assert
-            Assert.IsNotNull(retrievedServices);
-            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
-            Assert.IsTrue(retrievedServices[0] is ITestService1);
-            Assert.IsTrue(retrievedServices[0] == serviceInstance);
-        }
-
-        /// <summary>
-        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
-        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using said interface type.
-        /// With multiple services registered
-        /// </summary>
-        [Test]
-        public void ServiceManager_GetService_TopInterfaceType_WithPopulation()
-        {
-            // Arrange
-            var serviceInstance = new TestService1();
-            serviceManager.TryRegisterService<ITestService1>(serviceInstance);
-            var serviceInstance2 = new TestService2();
-            serviceManager.TryRegisterService<ITestService2>(serviceInstance2);
-
-            // Act
-            var retrievedServices = serviceManager.GetServices<ITestService1>();
-
-            // Assert
-            Assert.IsNotNull(retrievedServices);
-            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
-            Assert.IsTrue(retrievedServices[0] is ITestService1);
-            Assert.IsTrue(retrievedServices[0] == serviceInstance);
+            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
+            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
+            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service type does not match expected type {nameof(ITestService1)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+            Assert.IsTrue(retrievedService == serviceInstance, $"Returned service is not the expected instance.");
         }
 
         /// <summary>
@@ -82,38 +61,15 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Act
             var retrievedServices = serviceManager.GetServices<ITestService>();
+            var retrievedService = serviceManager.GetService<ITestService>();
 
             // Assert
-            Assert.IsNotNull(retrievedServices);
-            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
-            Assert.IsTrue(retrievedServices[0] is ITestService);
-            Assert.IsTrue(retrievedServices[0] == serviceInstance);
-        }
-
-
-        /// <summary>
-        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
-        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
-        /// was registered using it's dedicated interface type <see cref="ITestService1"/>.
-        /// With multiple services registered
-        /// </summary>
-        [Test]
-        public void ServiceManager_GetService_BaseInterfaceType_WithPopulation()
-        {
-            // Arrange
-            var serviceInstance = new TestService1();
-            serviceManager.TryRegisterService<ITestService1>(serviceInstance);
-            var serviceInstance2 = new TestService2();
-            serviceManager.TryRegisterService<ITestService2>(serviceInstance2);
-
-            // Act
-            var retrievedServices = serviceManager.GetServices<ITestService>();
-
-            // Assert
-            Assert.IsNotNull(retrievedServices, "No services returned from registry");
-            Assert.AreEqual(2, retrievedServices.Count, $"Number of services did not match the expected [2]");
-            Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service is not of type {typeof(ITestService)}");
-            Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
+            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
+            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
+            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service type does not match expected type {nameof(ITestService)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+            Assert.IsTrue(retrievedService == serviceInstance, $"Returned service is not the expected instance.");
         }
 
         /// <summary>
@@ -129,85 +85,15 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Act
             var retrievedServices = serviceManager.GetServices<ITestService1>();
+            var retrievedService = serviceManager.GetService<ITestService1>();
 
             // Assert
-            Assert.IsNotNull(retrievedServices);
-            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
-            Assert.IsTrue(retrievedServices[0] is ITestService1);
-            Assert.IsTrue(retrievedServices[0] == serviceInstance);
-        }
-
-        /// <summary>
-        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
-        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using the base interface type <see cref="ITestService"/>.
-        /// With multiple services registered
-        /// </summary>
-        [Test]
-        public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_WithPopulation()
-        {
-            // Arrange
-            var serviceInstance = new TestService1();
-            serviceManager.TryRegisterService<ITestService>(serviceInstance);
-            var serviceInstance2 = new TestService2();
-            serviceManager.TryRegisterService<ITestService2>(serviceInstance2);
-
-            // Act
-            var retrievedServices = serviceManager.GetServices<ITestService1>();
-
-            // Assert
-            Assert.IsNotNull(retrievedServices, "No services returned from registry");
-            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
-            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service is not of type {typeof(ITestService)}");
-            Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
-        }
-
-        /// <summary>
-        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/> 
-        /// with multiple instances of <see cref="TestService1"/> registered using all of its interfaces
-        /// </summary>
-        [Test]
-        public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_Twice()
-        {
-            // Arrange
-            var serviceInstance = new TestService1();
-            serviceManager.TryRegisterService<ITestService>(serviceInstance);
-            var serviceInstance2 = new TestService1();
-            serviceManager.TryRegisterService<ITestService1>(serviceInstance2);
-
-            // Act
-            var retrievedServices = serviceManager.GetServices<ITestService1>();
-
-            // Assert
-            Assert.IsNotNull(retrievedServices, "No services returned from registry");
-            Assert.AreEqual(2, retrievedServices.Count, $"Number of services did not match the expected [1]");
-            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service is not of type {typeof(ITestService)}");
-            Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
-        }
-
-        /// <summary>
-        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/> 
-        /// with multiple instances of <see cref="TestService1"/> registered using all of its interfaces
-        /// With multiple services registered
-        /// </summary>
-        [Test]
-        public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_Twice_WithPopulation()
-        {
-            // Arrange
-            var serviceInstance = new TestService1();
-            serviceManager.TryRegisterService<ITestService>(serviceInstance);
-            var serviceInstance2 = new TestService1();
-            serviceManager.TryRegisterService<ITestService1>(serviceInstance2);
-            var serviceInstance3 = new TestService2();
-            serviceManager.TryRegisterService<ITestService2>(serviceInstance3);
-
-            // Act
-            var retrievedServices = serviceManager.GetServices<ITestService1>();
-
-            // Assert
-            Assert.IsNotNull(retrievedServices, "No services returned from registry");
-            Assert.AreEqual(2, retrievedServices.Count, $"Number of services did not match the expected [1]");
-            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service is not of type {typeof(ITestService)}");
-            Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
+            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
+            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
+            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service type does not match expected type {nameof(ITestService1)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+            Assert.IsTrue(retrievedService == serviceInstance, $"Returned service is not the expected instance.");
         }
 
         /// <summary>
@@ -224,37 +110,15 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
 
             // Act
             var retrievedServices = serviceManager.GetServices<ITestService>();
+            var retrievedService = serviceManager.GetService<ITestService>();
 
             // Assert
-            Assert.IsNotNull(retrievedServices);
-            Assert.AreEqual(1, retrievedServices.Count, $"Number of services did not match the expected [1]");
-            Assert.IsTrue(retrievedServices[0] is ITestService);
-            Assert.IsTrue(retrievedServices[0] == serviceInstance);
-        }
-
-        /// <summary>
-        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
-        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
-        /// was registered using the base interface type <see cref="ITestService"/>.
-        /// With multiple services registered
-        /// </summary>
-        [Test]
-        public void ServiceManager_GetService_BaseInterfaceType_RegisteredByBaseInterfaceType_WithPopulation()
-        {
-            // Arrange
-            var serviceInstance = new TestService1();
-            serviceManager.TryRegisterService<ITestService>(serviceInstance);
-            var serviceInstance2 = new TestService2();
-            serviceManager.TryRegisterService<ITestService2>(serviceInstance2);
-
-            // Act
-            var retrievedServices = serviceManager.GetServices<ITestService>();
-
-            // Assert
-            Assert.IsNotNull(retrievedServices, "No services returned from registry");
-            Assert.AreEqual(2, retrievedServices.Count, $"Number of services did not match the expected [2]");
-            Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service is not of type {typeof(ITestService)}");
-            Assert.IsTrue(retrievedServices[0] == serviceInstance, "Instance of service does not match the created service");
+            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
+            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
+            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service type does not match expected type {nameof(ITestService)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+            Assert.IsTrue(retrievedService == serviceInstance, $"Returned service is not the expected instance.");
         }
 
         /// <summary>
@@ -278,17 +142,15 @@ namespace RealityCollective.ServiceFramework.Tests.L_ServiceInterfaceTests
             var retrievedServices2 = serviceManager.GetServices<ITestService2>();
 
             // Assert
-            Assert.AreEqual(2, retrievedServices.Count, $"Number of services did not match the expected [2]");
-            Assert.IsTrue(retrievedServices.Contains(serviceInstance1));
-            Assert.IsTrue(retrievedServices.Contains(serviceInstance2));
-            Assert.IsNotNull(retrievedServices1);
-            Assert.AreEqual(1, retrievedServices1.Count, $"Number of services did not match the expected [1]");
-            Assert.IsTrue(retrievedServices1[0] is ITestService1);
-            Assert.IsTrue(retrievedServices1[0] == serviceInstance1);
-            Assert.IsNotNull(retrievedServices2);
-            Assert.AreEqual(1, retrievedServices2.Count, $"Number of services did not match the expected [1]");
-            Assert.IsTrue(retrievedServices2[0] is ITestService2);
-            Assert.IsTrue(retrievedServices2[0] == serviceInstance2);
+            Assert.AreEqual(2, retrievedServices.Count, $"Expected {2} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsNotNull(retrievedServices1, $"Expected return value from {nameof(serviceManager.GetServices)} for {nameof(ITestService1)} to not be null.");
+            Assert.AreEqual(1, retrievedServices1.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices1[0] is ITestService1, $"Returned service type does not match expected type {nameof(ITestService1)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance1, $"Returned service is not the expected instance.");
+            Assert.IsNotNull(retrievedServices2, $"Expected return value from {nameof(serviceManager.GetServices)} for {nameof(ITestService2)} to not be null.");
+            Assert.AreEqual(1, retrievedServices2.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices2[0] is ITestService2, $"Returned service type does not match expected type {nameof(ITestService2)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance2, $"Returned service is not the expected instance.");
         }
 
         [TearDown]

--- a/Tests/Tests/ServiceManager_GetService_Tests.cs
+++ b/Tests/Tests/ServiceManager_GetService_Tests.cs
@@ -6,6 +6,7 @@ using RealityCollective.ServiceFramework.Services;
 using RealityCollective.ServiceFramework.Tests.Interfaces;
 using RealityCollective.ServiceFramework.Tests.Services;
 using RealityCollective.ServiceFramework.Tests.Utilities;
+using UnityEngine;
 
 namespace RealityCollective.ServiceFramework.Tests
 {
@@ -25,10 +26,11 @@ namespace RealityCollective.ServiceFramework.Tests
 
         /// <summary>
         /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
-        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using said interface type.
+        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using said interface type,
+        /// when the service is the only registered service.
         /// </summary>
         [Test]
-        public void ServiceManager_GetService_TopInterfaceType()
+        public void ServiceManager_GetService_TopInterfaceType_SingleService()
         {
             // Arrange
             var serviceInstance = new TestService1();
@@ -49,11 +51,37 @@ namespace RealityCollective.ServiceFramework.Tests
 
         /// <summary>
         /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
-        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
-        /// was registered using it's dedicated interface type <see cref="ITestService1"/>.
+        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using said interface type,
+        /// when there is other services registered.
         /// </summary>
         [Test]
-        public void ServiceManager_GetService_BaseInterfaceType()
+        public void ServiceManager_GetService_TopInterfaceType_MultiService()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService1>(serviceInstance);
+            serviceManager.TryRegisterService<ITestService2>(new TestService2());
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService1>();
+            var retrievedService = serviceManager.GetService<ITestService1>();
+
+            // Assert
+            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
+            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
+            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service type does not match expected type {nameof(ITestService1)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+            Assert.IsTrue(retrievedService == serviceInstance, $"Returned service is not the expected instance.");
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
+        /// was registered using it's dedicated interface type <see cref="ITestService1"/> and it is the only registered service.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_BaseInterfaceType_SingleService()
         {
             // Arrange
             var serviceInstance = new TestService1();
@@ -61,7 +89,105 @@ namespace RealityCollective.ServiceFramework.Tests
 
             // Act
             var retrievedServices = serviceManager.GetServices<ITestService>();
-            var retrievedService = serviceManager.GetService<ITestService>();
+            var retrievedService = serviceManager.GetService<ITestService>(false);
+
+            // Assert
+            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
+            Assert.IsNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to be null.");
+            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service type does not match expected type {nameof(ITestService)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
+        /// was registered using it's dedicated interface type <see cref="ITestService1"/> and there is other services registered.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_BaseInterfaceType_MultiService()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService1>(serviceInstance);
+            serviceManager.TryRegisterService<ITestService2>(new TestService2());
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService>();
+            var retrievedService = serviceManager.GetService<ITestService>(false);
+
+            // Assert
+            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
+            Assert.IsNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to be null.");
+            Assert.AreEqual(2, retrievedServices.Count, $"Expected {2} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service type does not match expected type {nameof(ITestService)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using the base interface type <see cref="ITestService"/>.
+        /// The service is the only registered service in this case.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_SingleService()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService>(serviceInstance);
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService1>();
+            var retrievedService = serviceManager.GetService<ITestService1>(false);
+
+            // Assert
+            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
+            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
+            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service type does not match expected type {nameof(ITestService1)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using the base interface type <see cref="ITestService"/>.
+        /// There is other registered services in this case.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_MultiService()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService>(serviceInstance);
+            serviceManager.TryRegisterService<ITestService>(new TestService2());
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService1>();
+            var retrievedService = serviceManager.GetService<ITestService1>(false);
+
+            // Assert
+            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
+            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
+            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
+            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service type does not match expected type {nameof(ITestService1)}.");
+            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+        }
+
+        /// <summary>
+        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
+        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
+        /// was registered using the base interface type <see cref="ITestService"/>. The service is the only registered service in this case.
+        /// </summary>
+        [Test]
+        public void ServiceManager_GetService_BaseInterfaceType_RegisteredByBaseInterfaceType_SingleService()
+        {
+            // Arrange
+            var serviceInstance = new TestService1();
+            serviceManager.TryRegisterService<ITestService>(serviceInstance);
+
+            // Act
+            var retrievedServices = serviceManager.GetServices<ITestService>();
+            var retrievedService = serviceManager.GetService<ITestService>(false);
 
             // Assert
             Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
@@ -74,45 +200,24 @@ namespace RealityCollective.ServiceFramework.Tests
 
         /// <summary>
         /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
-        /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using the base interface type <see cref="ITestService"/>.
-        /// </summary>
-        [Test]
-        public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType()
-        {
-            // Arrange
-            var serviceInstance = new TestService1();
-            serviceManager.TryRegisterService<ITestService>(serviceInstance);
-
-            // Act
-            var retrievedServices = serviceManager.GetServices<ITestService1>();
-            var retrievedService = serviceManager.GetService<ITestService1>();
-
-            // Assert
-            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
-            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
-            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
-            Assert.IsTrue(retrievedServices[0] is ITestService1, $"Returned service type does not match expected type {nameof(ITestService1)}.");
-            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
-            Assert.IsTrue(retrievedService == serviceInstance, $"Returned service is not the expected instance.");
-        }
-
-        /// <summary>
-        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
         /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
-        /// was registered using the base interface type <see cref="ITestService"/>.
+        /// was registered using the base interface type <see cref="ITestService"/>. There is other registered services in this case.
         /// </summary>
         [Test]
-        public void ServiceManager_GetService_BaseInterfaceType_RegisteredByBaseInterfaceType()
+        public void ServiceManager_GetService_BaseInterfaceType_RegisteredByBaseInterfaceType_MultiService()
         {
             // Arrange
             var serviceInstance = new TestService1();
             serviceManager.TryRegisterService<ITestService>(serviceInstance);
+            var secondServiceRegistrationSuccess = serviceManager.TryRegisterService<ITestService>(new TestService2());
 
             // Act
             var retrievedServices = serviceManager.GetServices<ITestService>();
-            var retrievedService = serviceManager.GetService<ITestService>();
+            var retrievedService = serviceManager.GetService<ITestService>(false);
 
             // Assert
+            Assert.IsFalse(secondServiceRegistrationSuccess, $"Expected {nameof(TestService2)} registration to fail, since {nameof(TestService1)} is already registered using {nameof(ITestService)}.");
+            UnityEngine.TestTools.LogAssert.Expect(LogType.Error, "There is already a ITestService.Test Service 1 registered!");
             Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
             Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
             Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
@@ -146,11 +251,11 @@ namespace RealityCollective.ServiceFramework.Tests
             Assert.IsNotNull(retrievedServices1, $"Expected return value from {nameof(serviceManager.GetServices)} for {nameof(ITestService1)} to not be null.");
             Assert.AreEqual(1, retrievedServices1.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
             Assert.IsTrue(retrievedServices1[0] is ITestService1, $"Returned service type does not match expected type {nameof(ITestService1)}.");
-            Assert.IsTrue(retrievedServices[0] == serviceInstance1, $"Returned service is not the expected instance.");
+            Assert.IsTrue(retrievedServices1[0] == serviceInstance1, $"Returned service is not the expected instance.");
             Assert.IsNotNull(retrievedServices2, $"Expected return value from {nameof(serviceManager.GetServices)} for {nameof(ITestService2)} to not be null.");
             Assert.AreEqual(1, retrievedServices2.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
             Assert.IsTrue(retrievedServices2[0] is ITestService2, $"Returned service type does not match expected type {nameof(ITestService2)}.");
-            Assert.IsTrue(retrievedServices[0] == serviceInstance2, $"Returned service is not the expected instance.");
+            Assert.IsTrue(retrievedServices2[0] == serviceInstance2, $"Returned service is not the expected instance.");
         }
 
         [TearDown]

--- a/Tests/Tests/ServiceManager_GetService_Tests.cs
+++ b/Tests/Tests/ServiceManager_GetService_Tests.cs
@@ -18,12 +18,6 @@ namespace RealityCollective.ServiceFramework.Tests
     {
         private ServiceManager serviceManager;
 
-        [SetUp]
-        public void SetupServiceManager_GetService_Tests()
-        {
-            TestUtilities.InitializeServiceManagerScene(ref serviceManager);
-        }
-
         /// <summary>
         /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
         /// using it's dedicated interface type <see cref="ITestService1"/> after registering it using said interface type,
@@ -32,6 +26,8 @@ namespace RealityCollective.ServiceFramework.Tests
         [Test]
         public void ServiceManager_GetService_TopInterfaceType_SingleService()
         {
+            TestUtilities.InitializeServiceManagerScene(ref serviceManager);
+
             // Arrange
             var serviceInstance = new TestService1();
             serviceManager.TryRegisterService<ITestService1>(serviceInstance);
@@ -57,6 +53,8 @@ namespace RealityCollective.ServiceFramework.Tests
         [Test]
         public void ServiceManager_GetService_TopInterfaceType_MultiService()
         {
+            TestUtilities.InitializeServiceManagerScene(ref serviceManager);
+
             // Arrange
             var serviceInstance = new TestService1();
             serviceManager.TryRegisterService<ITestService1>(serviceInstance);
@@ -83,6 +81,8 @@ namespace RealityCollective.ServiceFramework.Tests
         [Test]
         public void ServiceManager_GetService_BaseInterfaceType_SingleService()
         {
+            TestUtilities.InitializeServiceManagerScene(ref serviceManager);
+ 
             // Arrange
             var serviceInstance = new TestService1();
             serviceManager.TryRegisterService<ITestService1>(serviceInstance);
@@ -107,6 +107,8 @@ namespace RealityCollective.ServiceFramework.Tests
         [Test]
         public void ServiceManager_GetService_BaseInterfaceType_MultiService()
         {
+            TestUtilities.InitializeServiceManagerScene(ref serviceManager);
+
             // Arrange
             var serviceInstance = new TestService1();
             serviceManager.TryRegisterService<ITestService1>(serviceInstance);
@@ -132,6 +134,8 @@ namespace RealityCollective.ServiceFramework.Tests
         [Test]
         public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_SingleService()
         {
+            TestUtilities.InitializeServiceManagerScene(ref serviceManager);
+
             // Arrange
             var serviceInstance = new TestService1();
             serviceManager.TryRegisterService<ITestService>(serviceInstance);
@@ -156,6 +160,8 @@ namespace RealityCollective.ServiceFramework.Tests
         [Test]
         public void ServiceManager_GetService_TopInterfaceType_RegisteredByBaseInterfaceType_MultiService()
         {
+            TestUtilities.InitializeServiceManagerScene(ref serviceManager);
+
             // Arrange
             var serviceInstance = new TestService1();
             serviceManager.TryRegisterService<ITestService>(serviceInstance);
@@ -174,59 +180,6 @@ namespace RealityCollective.ServiceFramework.Tests
         }
 
         /// <summary>
-        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
-        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
-        /// was registered using the base interface type <see cref="ITestService"/>. The service is the only registered service in this case.
-        /// </summary>
-        [Test]
-        public void ServiceManager_GetService_BaseInterfaceType_RegisteredByBaseInterfaceType_SingleService()
-        {
-            // Arrange
-            var serviceInstance = new TestService1();
-            serviceManager.TryRegisterService<ITestService>(serviceInstance);
-
-            // Act
-            var retrievedServices = serviceManager.GetServices<ITestService>();
-            var retrievedService = serviceManager.GetService<ITestService>(false);
-
-            // Assert
-            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
-            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
-            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
-            Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service type does not match expected type {nameof(ITestService)}.");
-            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
-            Assert.IsTrue(retrievedService == serviceInstance, $"Returned service is not the expected instance.");
-        }
-
-        /// <summary>
-        /// This test will test whether we can retrieve a service instance of type <see cref="TestService1"/>
-        /// using the base interface type <see cref="ITestService"/> which is valid for all test services. The service instance
-        /// was registered using the base interface type <see cref="ITestService"/>. There is other registered services in this case.
-        /// </summary>
-        [Test]
-        public void ServiceManager_GetService_BaseInterfaceType_RegisteredByBaseInterfaceType_MultiService()
-        {
-            // Arrange
-            var serviceInstance = new TestService1();
-            serviceManager.TryRegisterService<ITestService>(serviceInstance);
-            var secondServiceRegistrationSuccess = serviceManager.TryRegisterService<ITestService>(new TestService2());
-
-            // Act
-            var retrievedServices = serviceManager.GetServices<ITestService>();
-            var retrievedService = serviceManager.GetService<ITestService>(false);
-
-            // Assert
-            Assert.IsFalse(secondServiceRegistrationSuccess, $"Expected {nameof(TestService2)} registration to fail, since {nameof(TestService1)} is already registered using {nameof(ITestService)}.");
-            UnityEngine.TestTools.LogAssert.Expect(LogType.Error, "There is already a ITestService.Test Service 1 registered!");
-            Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
-            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
-            Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
-            Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service type does not match expected type {nameof(ITestService)}.");
-            Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
-            Assert.IsTrue(retrievedService == serviceInstance, $"Returned service is not the expected instance.");
-        }
-
-        /// <summary>
         /// This test will test whether we can retrieve the service instances <see cref="TestService1"/>
         /// and <see cref="TestService2"/> using their respective dedicated interface types <see cref="ITestService1"/>
         /// and <see cref="ITestService2"/>. Additionally the test ensures both service instances can be retrieved
@@ -235,6 +188,8 @@ namespace RealityCollective.ServiceFramework.Tests
         [Test]
         public void ServiceManager_GetServices_BaseInterfaceType()
         {
+            TestUtilities.InitializeServiceManagerScene(ref serviceManager);
+ 
             // Arrange
             var serviceInstance1 = new TestService1();
             serviceManager.TryRegisterService<ITestService1>(serviceInstance1);
@@ -256,14 +211,6 @@ namespace RealityCollective.ServiceFramework.Tests
             Assert.AreEqual(1, retrievedServices2.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
             Assert.IsTrue(retrievedServices2[0] is ITestService2, $"Returned service type does not match expected type {nameof(ITestService2)}.");
             Assert.IsTrue(retrievedServices2[0] == serviceInstance2, $"Returned service is not the expected instance.");
-        }
-
-        [TearDown]
-        public void TearDownServiceManager_GetService_Tests()
-        {
-            serviceManager.Dispose();
-            serviceManager.DestroyAllServices();
-            serviceManager = null;
         }
     }
 }

--- a/Tests/Tests/ServiceManager_GetService_Tests.cs.meta
+++ b/Tests/Tests/ServiceManager_GetService_Tests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7747dc62522eaba4aaed21006847fd81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Adds a bunch of tests to ensure service retrieval using a base type works as expected. Also fixes another edge case when looking up the interface type for a service to be registered.

## Changes

What I said above.

## Breaking Changes

None.

## Related Submodule Changes

None

## Testing status

Includes unit tests.

### Manual testing status

Tested and verified in custom project with increased complexity and many custom services and providers.