### PR TITLE
Introduce ServiceManager.IsActiveAndInitialized

### DIFF
--- a/Editor/PropertyDrawers/ServiceDisplayEditor.cs
+++ b/Editor/PropertyDrawers/ServiceDisplayEditor.cs
@@ -54,7 +54,7 @@ namespace RealityCollective.ServiceFramework.Editor.PropertyDrawers
                 if (hook != null)
                 {
                     serviceName = hook.gameObject.name;
-                    if (ServiceManager.Instance != null && ServiceManager.Instance.IsInitialized)
+                    if (ServiceManager.IsActiveAndInitialized)
                     {
                         service = ServiceManager.Instance.GetAllServices()
                             .FirstOrDefault(p => p.Name == serviceName);

--- a/Editor/ServiceProfileInspector.cs
+++ b/Editor/ServiceProfileInspector.cs
@@ -379,7 +379,7 @@ namespace RealityCollective.ServiceFramework.Editor.Profiles
             {
                 serializedObject.ApplyModifiedProperties();
 
-                if (ServiceManager.Instance != null && ServiceManager.Instance.IsInitialized &&
+                if (ServiceManager.IsActiveAndInitialized &&
                     runtimePlatforms.arraySize > 0 &&
                     systemTypeReference.Type != null)
                 {
@@ -422,7 +422,7 @@ namespace RealityCollective.ServiceFramework.Editor.Profiles
 
             serializedObject.ApplyModifiedProperties();
 
-            if (ServiceManager.Instance != null && ServiceManager.Instance.IsInitialized)
+            if (ServiceManager.IsActiveAndInitialized)
             {
                 EditorApplication.delayCall += () => ServiceManager.Instance.ResetProfile(ServiceManager.Instance.ActiveProfile);
             }
@@ -430,7 +430,7 @@ namespace RealityCollective.ServiceFramework.Editor.Profiles
 
         private void OnElementReorderedCallback(ReorderableList list)
         {
-            if (ServiceManager.Instance != null && ServiceManager.Instance.IsInitialized)
+            if (ServiceManager.IsActiveAndInitialized)
             {
                 EditorApplication.delayCall += () => ServiceManager.Instance.ResetProfile(ServiceManager.Instance.ActiveProfile);
             }

--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -191,6 +191,12 @@ namespace RealityCollective.ServiceFramework.Services
         private static ServiceManager instance;
 
         /// <summary>
+        /// Gets whether there is an active <see cref="Instance"/> of the <see cref="ServiceManager"/>
+        /// available and it <see cref="IsInitialized"/>.
+        /// </summary>
+        public static bool IsActiveAndInitialized => Instance != null && Instance.IsInitialized;
+
+        /// <summary>
         /// Lock property for the Service Manager to prevent reinitialization
         /// </summary>
         private readonly object InitializedLock = new object();


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

I keep having to check if `ServcieManager.Instance` is not null and `ServiceManager.Intance.IsInitialized`. Also I keep getting `NRE`s in cases where some scripts or components, mostly editor windows / inspectors try to access `ServiceManager.Instance`, when it is not available. E.g. when editing prefabs or working in a scene that does not have the service manager.

This new API `ServiceManager.IsActiveAndInitialized` is a shorthand to check if the service manager is available.

## Changes

What I said above.

## Breaking Changes

- Breaks nothing

### Manual testing status

Tested.
