### PR TITLE
Updated Service drop downs to exclude template/base services

### DIFF
--- a/.github/workflows/buildupmpackages.yml
+++ b/.github/workflows/buildupmpackages.yml
@@ -34,7 +34,7 @@ jobs:
   # Run Unity unit tests defined in the package
   Run-Unit-Tests:
     name: Run Unity Unit Tests
-    needs: [Setup-Unity, Install-Unity-Editor]
+    needs: Setup-Unity
     uses: realitycollective/reusableworkflows/.github/workflows/rununityunittests.yml@main
     with:
       build-target: windows

--- a/.github/workflows/buildupmpackages.yml
+++ b/.github/workflows/buildupmpackages.yml
@@ -31,15 +31,6 @@ jobs:
       build-target: windows
       unityversion: ${{ needs.validate-environment.outputs.unityversion }}
 
-  Install-Unity-Editor:
-    if: ${{ needs.Setup-Unity.outputs.unityeditorinstalled }}  == '0'
-    needs: Setup-Unity
-    uses: realitycollective/reusableworkflows/.github/workflows/installunityeditor.yml@main
-    name: Install Unity Editor
-    with:
-      build-target: windows
-      unityversion: ${{ needs.Setup-Unity.outputs.unityeditorversion }}
-
   # Run Unity unit tests defined in the package
   Run-Unit-Tests:
     name: Run Unity Unit Tests

--- a/Editor/ServiceFrameworkPreferences.cs
+++ b/Editor/ServiceFrameworkPreferences.cs
@@ -18,9 +18,15 @@ namespace RealityCollective.ServiceFramework
     {
         public const string Editor_Menu_Keyword = "Reality Collective";
 
-        public const string Service_Framework_Editor_Menu_Keyword = Editor_Menu_Keyword + "/Service Framework"; 
+        public const string Service_Framework_Editor_Menu_Keyword = Editor_Menu_Keyword + "/Service Framework";
 
-        private static readonly string[] Package_Keywords = { "RealityCollective", "Mixed", "Reality","ServiceFramework" };
+        private static readonly string[] Package_Keywords = { "RealityCollective", "Mixed", "Reality", "ServiceFramework" };
+
+        public static readonly HashSet<Type> ExcludedTemplateServices = new HashSet<Type>
+        {
+            typeof(BaseService),
+            typeof(TemplateService)
+        };
 
         #region Show Inspector Debug View settings prompt
         private static readonly GUIContent ShowInspectorDebugViewContent = new GUIContent("Show services debug properties", "Enables the debug view for Service Profiles and Modules in the inspector view.");

--- a/Editor/ServiceProfileInspector.cs
+++ b/Editor/ServiceProfileInspector.cs
@@ -335,6 +335,9 @@ namespace RealityCollective.ServiceFramework.Editor.Profiles
                 };
                 TypeReferencePropertyDrawer.CreateNewTypeOverride = ServiceConstraint;
 
+                ICollection<Type> GetExcludedTypeCollection() => ServiceFrameworkPreferences.ExcludedTemplateServices;
+                TypeReferencePropertyDrawer.ExcludedTypeCollectionGetter = GetExcludedTypeCollection;
+
                 EditorGUI.BeginChangeCheck();
                 EditorGUI.PropertyField(typeRect, instancedType, instancedTypeContent);
                 systemTypeReference = new SystemType(instancedType);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Services",
     "Extensions"
   ],
-  "version": "1.0.0-preview.13",
+  "version": "1.0.1-preview.0",
   "unity": "2020.3",
   "homepage": "https://realitycollective.io",
   "bugs": {


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
Added filtering to ensure the BaseService and TemplateService do not show up in the Service/Module Selection

## Changes
<!-- Brief list of the targeted features that are being changed. -->

* BaseService
* TemplateService

No longer show up in drop-down selection for the ServiceManager Service Selection

