### PR TITLE
Fix service manager init not detected

### DIFF
--- a/Editor/Packages/PackageInstallerProfileInspector.cs
+++ b/Editor/Packages/PackageInstallerProfileInspector.cs
@@ -84,7 +84,7 @@ namespace RealityCollective.ServiceFramework.Editor.Packages
 
             if (GUILayout.Button("Install Package Service Configuration"))
             {
-                if (!(ServiceManager.Instance is null) && ServiceManager.Instance.HasActiveProfile)
+                if (ServiceManager.IsActiveAndInitialized && ServiceManager.Instance.HasActiveProfile)
                 {
                     EditorApplication.delayCall += () => PackageInstaller.InstallPackage(target as PackageInstallerProfile);
                 }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

In some cases the package installer inspector would falsely claim
"Unable to install package because not service manger was found"

This fix addresses that issue.