### PR TITLE
Update Utilities dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "dependencies": {
     "com.unity.editorcoroutines": "1.0.0",
     "com.unity.addressables": "1.20.5",
-    "com.realitycollective.utilities": "1.0.0"
+    "com.realitycollective.utilities": "1.0.3"
   }
 }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Updated the Utilities package dependency.
v1.0.0 still had the CanvasExtensions that are part of the Toolkit Core. This leads to a GUID conflict when using the toolkit.
It's resolved by making the Utilities dependency of the SF v1.0.3 which does not have that extension anymore.