### PR TITLE
Add ServiceManager.WaitUntilInitializedAsync API

### DIFF
--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -200,6 +200,11 @@ namespace RealityCollective.ServiceFramework.Services
         private readonly object InitializedLock = new object();
 
         /// <summary>
+        /// The <see cref="ServiceManager"/> <see cref="Instance"/> has finished initialzing.
+        /// </summary>
+        public static event Action Initialized;
+
+        /// <summary>
         /// Constructor
         /// Each Service Manager MUST have a managed GameObject that can route the MonoBehaviours to, if you do not provide a <see cref="GameObject"/>, then a new <see cref="ServiceManagerInstance"/> will be created for you.
         /// </summary>
@@ -253,6 +258,7 @@ namespace RealityCollective.ServiceFramework.Services
             }
 
             InitializeInstance(profile);
+            Initialized?.Invoke();
         }
 
         private void InitializeInstance(ServiceProvidersProfile profile)
@@ -355,19 +361,6 @@ namespace RealityCollective.ServiceFramework.Services
                 await Task.Yield();
                 timeout -= Time.deltaTime;
             }
-        }
-
-        /// <summary>
-        /// Waits for the <see cref="ServiceManager"/> to initialize until
-        /// <paramref name="timeout"/> seconds have passed or <see cref="IsActiveAndInitialized"/>.
-        /// </summary>
-        /// <param name="timeout">Time to wait in seconds for <see cref="IsActiveAndInitialized"/> to become <c>true</c>.</param>
-        /// <param name="onComplete">Completion callback run when <see cref="IsActiveAndInitialized"/>.</param>
-        [Obsolete("Use " + nameof(WaitUntilInitializedAsync) + " instead.")]
-        public static async void EnsureIsInitialized(float timeout, Action onComplete)
-        {
-            await WaitUntilInitializedAsync(timeout);
-            onComplete?.Invoke();
         }
 
         /// <summary>

--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -202,7 +202,7 @@ namespace RealityCollective.ServiceFramework.Services
         /// <summary>
         /// The <see cref="ServiceManager"/> <see cref="Instance"/> has finished initialzing.
         /// </summary>
-        public static event Action Initialized;
+        public static event Action<ServiceManager> Initialized;
 
         /// <summary>
         /// Constructor
@@ -258,7 +258,7 @@ namespace RealityCollective.ServiceFramework.Services
             }
 
             InitializeInstance(profile);
-            Initialized?.Invoke();
+            Initialized?.Invoke(Instance);
         }
 
         private void InitializeInstance(ServiceProvidersProfile profile)

--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -184,11 +184,9 @@ namespace RealityCollective.ServiceFramework.Services
         #region Instance Management
 
         /// <summary>
-        /// Returns the Singleton instance of the classes type.
+        /// Returns the singleton instance of the <see cref="ServiceManager"/>.
         /// </summary>
-        public static ServiceManager Instance => instance;
-
-        private static ServiceManager instance;
+        public static ServiceManager Instance { get; private set; }
 
         /// <summary>
         /// Gets whether there is an active <see cref="Instance"/> of the <see cref="ServiceManager"/>
@@ -230,7 +228,7 @@ namespace RealityCollective.ServiceFramework.Services
 
         public void Initialize(GameObject instanceGameObject = null, ServiceProvidersProfile profile = null)
         {
-            instance = null;
+            Instance = null;
             serviceManagerInstanceGuid = Guid.NewGuid();
 
             ServiceManagerInstance serviceManagerInstance;
@@ -265,12 +263,12 @@ namespace RealityCollective.ServiceFramework.Services
                     ServiceManager.Instance.ServiceManagerInstanceGuid != this.serviceManagerInstanceGuid)
                 {
                     Debug.LogWarning($"There are multiple instances of the {nameof(ServiceManager)} in this project, is this expected?");
-                    Debug.Log($"Instance [{instance.ServiceManagerInstanceGuid}] - This [{this.ServiceManagerInstanceGuid}]");
+                    Debug.Log($"Instance [{Instance.ServiceManagerInstanceGuid}] - This [{this.ServiceManagerInstanceGuid}]");
                 }
 
                 if (IsInitialized) { return; }
 
-                instance = this;
+                Instance = this;
                 activeProfile = profile;
 
                 Application.quitting += () =>
@@ -328,14 +326,14 @@ namespace RealityCollective.ServiceFramework.Services
         /// <summary>
         /// Returns whether the instance has been initialized or not.
         /// </summary>
-        public bool IsInitialized => instance != null && serviceManagerInstanceGameObject.IsNotNull();
+        public bool IsInitialized => Instance != null && serviceManagerInstanceGameObject.IsNotNull();
 
         /// <summary>
         /// function to determine if the <see cref="ServiceManager"/> class has been initialized or not.
         /// </summary>
         public bool ConfirmInitialized()
         {
-            var access = instance;
+            var access = Instance;
             Debug.Assert(IsInitialized.Equals(access != null));
             return IsInitialized;
         }
@@ -357,6 +355,19 @@ namespace RealityCollective.ServiceFramework.Services
                 await Task.Yield();
                 timeout -= Time.deltaTime;
             }
+        }
+
+        /// <summary>
+        /// Waits for the <see cref="ServiceManager"/> to initialize until
+        /// <paramref name="timeout"/> seconds have passed or <see cref="IsActiveAndInitialized"/>.
+        /// </summary>
+        /// <param name="timeout">Time to wait in seconds for <see cref="IsActiveAndInitialized"/> to become <c>true</c>.</param>
+        /// <param name="onComplete">Completion callback run when <see cref="IsActiveAndInitialized"/>.</param>
+        [Obsolete("Use " + nameof(WaitUntilInitializedAsync) + " instead.")]
+        public static async void EnsureIsInitialized(float timeout, Action onComplete)
+        {
+            await WaitUntilInitializedAsync(timeout);
+            onComplete?.Invoke();
         }
 
         /// <summary>
@@ -1918,9 +1929,9 @@ namespace RealityCollective.ServiceFramework.Services
 
         private void OnDispose(bool finalizing)
         {
-            if (instance == this)
+            if (Instance == this)
             {
-                instance = null;
+                Instance = null;
             }
         }
 

--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -345,6 +345,16 @@ namespace RealityCollective.ServiceFramework.Services
         /// </summary>
         public void InitializeServiceManager() => InitializeServiceLocator();
 
+        public static async Task WaitUntilInitializedAsync()
+        {
+            var timeout = 0f;
+            while (!IsActiveAndInitialized && timeout <= 10f)
+            {
+                await Task.Yield();
+                timeout += Time.deltaTime;
+            }
+        }
+
         /// <summary>
         /// Once all services are registered and properties updated, the Service Manager will initialize all active services.
         /// This ensures all services can reference each other once started.

--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -345,13 +345,17 @@ namespace RealityCollective.ServiceFramework.Services
         /// </summary>
         public void InitializeServiceManager() => InitializeServiceLocator();
 
-        public static async Task WaitUntilInitializedAsync()
+        /// <summary>
+        /// Waits for the <see cref="ServiceManager"/> to initialize until
+        /// <paramref name="timeout"/> seconds have passed or <see cref="IsActiveAndInitialized"/>.
+        /// </summary>
+        /// <param name="timeout">Time to wait in seconds for <see cref="IsActiveAndInitialized"/> to become <c>true</c>.</param>
+        public static async Task WaitUntilInitializedAsync(float timeout = 10f)
         {
-            var timeout = 0f;
-            while (!IsActiveAndInitialized && timeout <= 10f)
+            while (!IsActiveAndInitialized && timeout > 0f)
             {
                 await Task.Yield();
-                timeout += Time.deltaTime;
+                timeout -= Time.deltaTime;
             }
         }
 


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Some MonoBehaviour components rely on the ServiceManager to be initialized to retrieve service dependencies. If said components are in the Base scene e.g. they might attempt to get a service before the service manager is ready. A new API was addded that allows conveniently waiting for the manager to init.

### Usage

```
private async void OnEnable()
        {
            await ServiceManager.WaitUntilInitializedAsync();
            cameraService = await ServiceManager.Instance.GetServiceAsync<ICameraService>();
            cameraService.CameraOutOfBounds += CameraService_CameraOutOfBounds;
            cameraService.CameraBackInBounds += CameraService_CameraBackInBounds;
        }
```