### PR TITLE
Bump utilities package so that clean install into Unity 2023 project builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "com.unity.editorcoroutines": "1.0.0",
     "com.unity.addressables": "1.20.5",
-    "com.realitycollective.utilities": "1.0.5-pre.2",
+    "com.realitycollective.utilities": "1.0.5-pre.3",
     "com.unity.ugui": "1.0.0"
   }
 }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Just bumps the Utilities dependency to include the fix for Unity 2023 when installing the SF into a new project.