### PR TITLE
Fix type cache generation issues

### DIFF
--- a/Runtime/Utilities/TypeCache.cs
+++ b/Runtime/Utilities/TypeCache.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace RealityCollective.ServiceFramework
 {
-    public static class TypeCache 
+    public static class TypeCache
     {
         private static readonly Dictionary<Guid, Type> typeCache = new Dictionary<Guid, Type>();
 


### PR DESCRIPTION
# Reality Collective - Service Framework Pull Request

## Overview

- Fix issue where any user assemblies or third party assemblies that would happen to include any of the blacklisted assembly names, such as "Mono", would automatically be excluded from the type cache even though we do not want to do that
- Fix assemblies loop iterated backwards but never runs for index 0
- Fix blacklisted assemblies array iterated backwards but index 0 is never checked
