### PR TITLE
Enable searching for inherited services

### DIFF
--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -1048,18 +1048,29 @@ namespace RealityCollective.ServiceFramework.Services
 
             if (!CanGetService(interfaceType, serviceName)) { return false; }
 
+
             if (activeServices.TryGetValue(interfaceType, out var service))
             {
                 serviceInstance = service;
-
-                if (CheckServiceMatch(interfaceType, serviceName, interfaceType, service))
+            }
+            else
+            {
+                foreach (var serviceInhertance in activeServices)
                 {
-                    return true;
+                    if (interfaceType.IsAssignableFrom(serviceInhertance.Key))
+                    {
+                        serviceInstance = serviceInhertance.Value;
+                        break;
+                    }
                 }
-
-                serviceInstance = null;
             }
 
+            if (serviceInstance != null && CheckServiceMatch(interfaceType, serviceName, interfaceType, service))
+            {
+                return true;
+            }
+
+            serviceInstance = null;
             return false;
         }
 

--- a/Tests/Tests/ServiceManager_GetService_Tests.cs
+++ b/Tests/Tests/ServiceManager_GetService_Tests.cs
@@ -93,10 +93,11 @@ namespace RealityCollective.ServiceFramework.Tests.M_ServiceManager_GetService
 
             // Assert
             Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
-            Assert.IsNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to be null.");
+            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
             Assert.AreEqual(1, retrievedServices.Count, $"Expected {1} service to be returned, but got {retrievedServices.Count} instead.");
             Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service type does not match expected type {nameof(ITestService)}.");
             Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+            Assert.IsTrue(retrievedService == serviceInstance, $"Returned service is not the expected instance.");
         }
 
         /// <summary>
@@ -120,10 +121,11 @@ namespace RealityCollective.ServiceFramework.Tests.M_ServiceManager_GetService
 
             // Assert
             Assert.IsNotNull(retrievedServices, $"Expected return value from {nameof(serviceManager.GetServices)} to not be null.");
-            Assert.IsNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to be null.");
+            Assert.IsNotNull(retrievedService, $"Expected return value from {nameof(serviceManager.GetService)} to not be null.");
             Assert.AreEqual(2, retrievedServices.Count, $"Expected {2} service to be returned, but got {retrievedServices.Count} instead.");
             Assert.IsTrue(retrievedServices[0] is ITestService, $"Returned service type does not match expected type {nameof(ITestService)}.");
             Assert.IsTrue(retrievedServices[0] == serviceInstance, $"Returned service is not the expected instance.");
+            Assert.IsTrue(retrievedService == serviceInstance, $"Returned service is not the expected instance.");
         }
 
         /// <summary>


### PR DESCRIPTION
# Reality Collective - Service Framework Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

In cases where you want a generic search for services implemented with a base interface, this change enables this capability, e.g.

Base Interface : IApplicationSettings
Generic Interface : IMyApplicationSettings : IApplication Settings.

Now the service is searchable by either its base interface "IMyApplicationSettings" or its inherited interface "IApplicationSettings".

## Warning, if there are multiple services registered with the same inherited interface, ONLY the first registered instance would be found.  To get all services returned with the inherited interface, then "GetAllServices" should be used.

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Updates 

## Breaking Changes
<!--  Are there any breaking changes included in this change that would prevent or cause issue for existing projects? -->

- Updates "TryGetService" to allow an additional search for inherited interface should the initial search fail
- Updates tests which were affected by this chaneg (expected null where now it is not)

## Testing status
* Includes unit tests.


## Breaking change

Should implementations expect a failure where inherited services look for a single service, these will now return the first service with the inherited interface.