### PR TITLE
Adding service dependency injection feature for Services

### DIFF
--- a/Tests/TestData/Interfaces/ITestDependencyService1.cs
+++ b/Tests/TestData/Interfaces/ITestDependencyService1.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace RealityCollective.ServiceFramework.Tests.Interfaces
+{
+    public interface ITestDependencyService1 : ITestService { }
+}

--- a/Tests/TestData/Interfaces/ITestDependencyService1.cs.meta
+++ b/Tests/TestData/Interfaces/ITestDependencyService1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e3d9b661b1d4924c8317c9deb4ae4bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestData/Interfaces/ITestDependencyService2.cs
+++ b/Tests/TestData/Interfaces/ITestDependencyService2.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace RealityCollective.ServiceFramework.Tests.Interfaces
+{
+    public interface ITestDependencyService2 : ITestService { }
+}

--- a/Tests/TestData/Interfaces/ITestDependencyService2.cs.meta
+++ b/Tests/TestData/Interfaces/ITestDependencyService2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8279b734f117b534fbe064b5816f7371
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestData/Services/DependencyTestService1.cs
+++ b/Tests/TestData/Services/DependencyTestService1.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityCollective.ServiceFramework.Definitions;
+using RealityCollective.ServiceFramework.Services;
+using RealityCollective.ServiceFramework.Tests.Interfaces;
+using UnityEngine;
+
+namespace RealityCollective.ServiceFramework.Tests.Services
+{
+    public class DependencyTestService1 : BaseServiceWithConstructor, ITestDependencyService1
+    {
+        public const string TestName = "Dependency Test Service 1";
+        public ITestService1 testService1;
+
+        public DependencyTestService1(string name, uint priority, BaseProfile profile, ITestService1 testService1)
+            : base(name, priority)
+        {
+            this.testService1 = testService1;
+        }
+
+        public override void Initialize()
+        {
+            //base.Initialize();
+            Debug.Log($"{TestName} is Initialised");
+        }
+
+        public override bool RegisterServiceModules => false;
+    }
+}

--- a/Tests/TestData/Services/DependencyTestService1.cs.meta
+++ b/Tests/TestData/Services/DependencyTestService1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 565e01424423d754ca5e91d6bf76293e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestData/Services/DependencyTestService2.cs
+++ b/Tests/TestData/Services/DependencyTestService2.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityCollective.ServiceFramework.Definitions;
+using RealityCollective.ServiceFramework.Services;
+using RealityCollective.ServiceFramework.Tests.Interfaces;
+using UnityEngine;
+
+namespace RealityCollective.ServiceFramework.Tests.Services
+{
+    public class DependencyTestService2 : BaseServiceWithConstructor, ITestDependencyService2
+    {
+        public const string TestName = "Dependency Test Service 2";
+        public ITestService1 testService1;
+        public ITestDependencyService1 testService2;
+
+        public DependencyTestService2(string name, uint priority, BaseProfile profile, ITestService1 testService1, ITestDependencyService1 testService2)
+            : base(name, priority)
+        {
+            this.testService1 = testService1;
+            this.testService2 = testService2;
+        }
+
+        public override void Initialize()
+        {
+            //base.Initialize();
+            Debug.Log($"{TestName} is Initialised");
+        }
+
+        public override bool RegisterServiceModules => false;
+    }
+}

--- a/Tests/TestData/Services/DependencyTestService2.cs.meta
+++ b/Tests/TestData/Services/DependencyTestService2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8042b6168286ece4cb498a3c24ef4149
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Tests/Service Dependency Tests.cs
+++ b/Tests/Tests/Service Dependency Tests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Reality Collective. All rights reserved.
+
+using NUnit.Framework;
+using RealityCollective.ServiceFramework.Definitions;
+using RealityCollective.ServiceFramework.Definitions.Platforms;
+using RealityCollective.ServiceFramework.Interfaces;
+using RealityCollective.ServiceFramework.Services;
+using RealityCollective.ServiceFramework.Tests.Interfaces;
+using RealityCollective.ServiceFramework.Tests.Services;
+using RealityCollective.ServiceFramework.Tests.Utilities;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace RealityCollective.ServiceFramework.Tests.N_ServiceDependency
+{
+    internal class ServiceDependencyTests
+    {
+        private ServiceManager testServiceManager;
+
+        #region Service Retrieval
+
+        [Test]
+        public void Test_10_01_ParentServiceRegistration()
+        {
+            TestUtilities.InitializeServiceManagerScene(ref testServiceManager);
+
+            var activeServiceCount = testServiceManager.ActiveServices.Count;
+
+            var config = new ServiceConfiguration<ITestService1>(typeof(TestService1), TestService1.TestName, 1, AllPlatforms.Platforms, null);
+            var serviceResult = testServiceManager.TryCreateAndRegisterService<ITestService1>(config, out ITestService1 testService1);
+
+            // Tests
+            Assert.IsTrue(serviceResult, "Test service was not registered");
+            Assert.IsNotNull(testService1, "Test service instance was not returned");
+            Assert.IsTrue(testService1.ServiceGuid != System.Guid.Empty, "No GUID generated for the test service");
+            Assert.AreEqual(activeServiceCount + 1, testServiceManager.ActiveServices.Count, "More or less services found than was expected");
+        }
+
+        [Test]
+        public void Test_10_02_DependentServiceRegistration()
+        {
+            TestUtilities.InitializeServiceManagerScene(ref testServiceManager);
+
+            var activeServiceCount = testServiceManager.ActiveServices.Count;
+
+            var config = new ServiceConfiguration<ITestService1>(typeof(TestService1), TestService1.TestName, 1, AllPlatforms.Platforms, null);
+            testServiceManager.TryCreateAndRegisterService<ITestService1>(config, out ITestService1 testService1);
+
+            var config2 = new ServiceConfiguration<ITestDependencyService1>(typeof(DependencyTestService1), "Dependency Service", 1, AllPlatforms.Platforms, null);
+            var serviceResult2 = testServiceManager.TryCreateAndRegisterService<ITestDependencyService1>(config2, out ITestDependencyService1 testService2);
+
+            // Tests
+            Assert.IsTrue(serviceResult2, "Test service 2 was not registered");
+            Assert.IsNotNull(testService2, "Test service 2 instance was not returned");
+            Assert.IsTrue(testService2.ServiceGuid == System.Guid.Empty, "GUID found for the second test service when none configured");
+            Assert.AreEqual(activeServiceCount + 2, testServiceManager.ActiveServices.Count, "More or less services found than was expected");
+            Assert.IsNotNull((testService2 as DependencyTestService1)?.testService1, "Dependent service was not injected with parent service");
+        }
+
+        [Test]
+        public void Test_10_03_DependentServiceRegistrationMissingDependency()
+        {
+            TestUtilities.InitializeServiceManagerScene(ref testServiceManager);
+
+            var activeServiceCount = testServiceManager.ActiveServices.Count;
+
+            var config2 = new ServiceConfiguration<ITestDependencyService1>(typeof(DependencyTestService1), "Dependency Service", 1, AllPlatforms.Platforms, null);
+            var serviceResult2 = testServiceManager.TryCreateAndRegisterService<ITestDependencyService1>(config2, out ITestDependencyService1 testService2);
+            LogAssert.Expect(LogType.Error, new Regex("Failed to find an ITestService1 service to inject into testService1!"));
+            LogAssert.Expect(LogType.Error, new Regex("Failed to register the DependencyTestService1 service due to missing dependencies. Ensure all dependencies are registered prior to registering this service."));
+
+            // Tests
+            Assert.IsFalse(serviceResult2, "Test service 2 was registered, when it should not have been");
+            Assert.IsNull(testService2, "Test service 2 instance was returned");
+            Assert.AreEqual(activeServiceCount, testServiceManager.ActiveServices.Count, "More or less services found than was expected");
+            Assert.IsNull((testService2 as DependencyTestService1)?.testService1, "Dependent service was not injected with parent service");
+        }
+
+                [Test]
+        public void Test_10_04_MultipleDependentServiceRegistration()
+        {
+            TestUtilities.InitializeServiceManagerScene(ref testServiceManager);
+
+            var activeServiceCount = testServiceManager.ActiveServices.Count;
+
+            var config = new ServiceConfiguration<ITestService1>(typeof(TestService1), TestService1.TestName, 1, AllPlatforms.Platforms, null);
+            testServiceManager.TryCreateAndRegisterService<ITestService1>(config, out ITestService1 testService1);
+
+            var config2 = new ServiceConfiguration<ITestDependencyService1>(typeof(DependencyTestService1), "Dependency Service", 1, AllPlatforms.Platforms, null);
+            testServiceManager.TryCreateAndRegisterService<ITestDependencyService1>(config2, out ITestDependencyService1 testService2);
+
+            var config3 = new ServiceConfiguration<ITestDependencyService2>(typeof(DependencyTestService2), "Dependency Service", 1, AllPlatforms.Platforms, null);
+            var serviceResult3 = testServiceManager.TryCreateAndRegisterService<ITestDependencyService2>(config3, out ITestDependencyService2 testService3);
+
+            // Tests
+            Assert.IsTrue(serviceResult3, "Test service 3 was not registered");
+            Assert.IsNotNull(testService3, "Test service 3 instance was not returned");
+            Assert.IsTrue(testService3.ServiceGuid == System.Guid.Empty, "GUID found for the second test service when none configured");
+            Assert.AreEqual(activeServiceCount + 3, testServiceManager.ActiveServices.Count, "More or less services found than was expected");
+            Assert.IsNotNull((testService3 as DependencyTestService2)?.testService1, "Dependent service was not injected with parent service");
+            Assert.IsNotNull((testService3 as DependencyTestService2)?.testService2, "Dependent service was not injected with parent service");
+        }
+
+        #endregion Service Retrieval
+    }
+}

--- a/Tests/Tests/Service Dependency Tests.cs.meta
+++ b/Tests/Tests/Service Dependency Tests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 668549c1580871d40b91ac8202ddad05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Reality Collective - Service Framework Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

Adding the much anticipated Dependency Injection feature, which allows constructors like the following

```csharp
public DependencyTestService2(string name, uint priority, BaseProfile profile, IParentService parentService)
```

So long as the dependent service is registered in the Service Configuration PRIOR to the above service being registered, it will automatically inject the reference to the existing registered service.
Removes the need for unnecessary service wind up functionality within a service.

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Adds a new `TryGetService` call for simplification
- Adds dependency check if there are additional service interfaces included in the primary constructor

> [!NOTE]
> Only the primary constructor is inspected and ONLY parameters deriving from `IService` will be included.  Any other types of parameters are likely to introduce errors.

## Breaking Changes
<!--  Are there any breaking changes included in this change that would prevent or cause issue for existing projects? -->

- None

## Testing status
<!-- Remove the options that do not apply -->

* Includes unit tests.

## Notes

This is designed for Services only at present.  Modules will be evaluated in future updates