### PR TITLE
Update TryGetServiceProfile Parameter Type for Greater Flexibility

### DIFF
--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -1689,7 +1689,7 @@ namespace RealityCollective.ServiceFramework.Services
         /// <param name="profile">The profile instance.</param>
         /// <param name="rootProfile">Optional root profile reference.</param>
         /// <returns>True if a <see cref="TService"/> type is matched and a valid <see cref="TProfile"/> is found, otherwise false.</returns>
-        public bool TryGetServiceProfile<TService, TProfile>(out TProfile profile, ServiceProvidersProfile rootProfile = null)
+        public bool TryGetServiceProfile<TService, TProfile>(out TProfile profile, BaseServiceProfile<IService> rootProfile = null)
             where TService : IService
             where TProfile : BaseProfile
         {


### PR DESCRIPTION
**Change:** Modified the rootProfile parameter in TryGetServiceProfile to use BaseServiceProfile<IService> as its type.

**Impact:** This adjustment increases flexibility, enabling developers to search for service profiles across both SceneServiceProvidersProfile and ServiceProvidersProfile.

**Benefit:** Provides a more versatile approach to locating and using service profiles.

**Testing:** Test cases still need to be implemented. These should include calls to TryGetServiceProfile with rootProfile set as instances of both SceneServiceProvidersProfile and ServiceProvidersProfile, ensuring compatibility and correctness across these profile types.
