### PR TITLE
Remove service ordering, now dictated by the profile service order

### DIFF
--- a/Runtime/Services/ServiceManager.cs
+++ b/Runtime/Services/ServiceManager.cs
@@ -421,8 +421,7 @@ namespace RealityCollective.ServiceFramework.Services
 
             if (ActiveProfile?.ServiceConfigurations != null)
             {
-                var orderedConfig = ActiveProfile.ServiceConfigurations.OrderBy(s => s.Priority).ToArray();
-                TryRegisterServiceConfigurations(orderedConfig);
+                TryRegisterServiceConfigurations(ActiveProfile.ServiceConfigurations);
             }
 
             var activeSceneName = SceneManager.GetActiveScene().name;
@@ -779,20 +778,17 @@ namespace RealityCollective.ServiceFramework.Services
                 return true;
             }
 
-            Debug.Log($"Constructor: {primaryConstructor}");
-
             foreach (var parameter in parameters)
             {
                 if (parameter.ParameterType.IsInterface && typeof(IService).IsAssignableFrom(parameter.ParameterType))
                 {
                     if (TryGetService(parameter.ParameterType, out var dependency))
                     {
-                        Debug.Log($"Injecting {dependency.Name} into {parameter.Name}");
                         args = args.AddItem(dependency);
                     }
                     else
                     {
-                        Debug.LogError($"Failed to find an {parameter.ParameterType.Name} service to inject into {parameter.Name}!");
+                        Debug.LogError($"Failed to find an {parameter.ParameterType.Name} service to inject into parameter {parameter.Name} for service {concreteType.Name}!");
                     }
                 }
             }


### PR DESCRIPTION
# Reality Collective - Service Framework Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

Since the addition of Dependency Injection, the "automatic" priority order is causing issue with Service Ordering. This PR removes the feature to order services by priority until it can be updated to work better with DI (ordering services by dependency need).

Also added some log clean-up.

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Fixes: issue where the order of services was being made by the Unity inspector
